### PR TITLE
Update prometheus-operator and serviceMonitor fix

### DIFF
--- a/scripts/install_base_components.sh
+++ b/scripts/install_base_components.sh
@@ -238,7 +238,7 @@ kubectl apply -f manifests/storageclass-retain-nocache.yaml
 # Install prometheus-operator
 echo "Installing prometheus-operator"
 
-helm upgrade --install prometheus-operator stable/prometheus-operator -f manifests/prometheus-operator-values.yaml
+helm upgrade --install prometheus-operator stable/prometheus-operator -f manifests/prometheus-operator-values.yaml --set prometheus.prometheusSpec.serviceMonitorSelector.any=true
 
 # Install Prometheus Ingress with HTTP Basic Authentication
 


### PR DESCRIPTION
Updates prometheus-operator to v 3.0.0 (latest).

Makes prometheus-operator use any servicemonitor instead of just those correctly labeled (which tend to change).