### PR TITLE
Use publicly available link for Radix Logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Logo](https://github.com/equinor/radix-resources/blob/master/logo/Banner%20energy%20red@2x.png?raw=true)
+![Radix Logo](https://www.radix.equinor.com/images/banner-logo.svg)
 
 [Public site](https://www.radix.equinor.com)
 


### PR DESCRIPTION
Use https://www.radix.equinor.com/images/banner-logo.svg instead of an image from another repository