### PR TITLE
OR-560: networkpolicy required label on default namespace

### DIFF
--- a/scripts/install_base_components.sh
+++ b/scripts/install_base_components.sh
@@ -459,7 +459,7 @@ helm upgrade --install radix-operator \
 
 rm -f radix-operator-values.yaml
 
-## For network security policy applied by operator to work, the default namespace need to be labeled
+## For network security policy applied by operator to work, the namespace hosting prometheus and nginx-ingress-controller need to be labeled
 kubectl label ns default purpose=radix-base-ns --overwrite
 
 #######################################################################################


### PR DESCRIPTION
radix operator applies a network (security) policy, stopping traffic network between namespaces (done in https://github.com/equinor/radix-operator/pull/206).  Prometheus and nginx-ingress-controller need to communicate with all ns to work, which operator opens up for, through allowing traffic from ns with label `purpose: radix-base-ns` and pod labeled with app: prometheus or app: nginx-ingress