### PR TITLE
Update resource request and cluster size

### DIFF
--- a/scripts/install_base_components.sh
+++ b/scripts/install_base_components.sh
@@ -489,8 +489,8 @@ helm upgrade --install humio \
     --set ingress.tlsSecretName=cluster-wildcard-tls-cert \
     --set resources.limits.cpu=4 \
     --set resources.limits.memory=16000Mi \
-    --set resources.requests.cpu=0.5 \
-    --set resources.requests.memory=2000Mi \
+    --set resources.requests.cpu=0.2 \
+    --set resources.requests.memory=800Mi \
     -f humio-values.yaml
 
 rm -f humio-values.yaml

--- a/scripts/install_cluster.sh
+++ b/scripts/install_cluster.sh
@@ -146,9 +146,9 @@ else
     credentials_source="$CREDENTIALS_FILE"
 fi
 
-NODE_COUNT_DEV=4 # You need 4xStandard_DS1_v2 nodes to be able to run the complete radix platform
-NODE_VM_SIZE_DEV=Standard_DS1_v2
-NODE_VM_SIZE_DEV_DESCRIPTION="1vCPU, 3.5GB RAM"
+NODE_COUNT_DEV=1
+NODE_VM_SIZE_DEV=Standard_DS2_v2
+NODE_VM_SIZE_DEV_DESCRIPTION="2vCPU, 7GB RAM"
 
 echo "Select cluster size and capacity: "
 echo "1) (default) Production size, $NODE_COUNT x $NODE_VM_SIZE ($NODE_VM_SIZE_DESCRIPTION)"
@@ -261,7 +261,7 @@ az aks get-credentials --overwrite-existing --admin --resource-group "$RESOURCE_
 
 echo "###########################################################"
 echo ""
-echo "MANUAL STEP: AKS DIAGNOSTIC LOGS"
+echo "FOR PRODUCTION ONLY: MANUAL STEP: AKS DIAGNOSTIC LOGS"
 echo ""
 echo "You need to manually enable AKS Diagnostic logs. See https://docs.microsoft.com/en-us/azure/aks/view-master-logs ."
 echo ""

--- a/scripts/manifests/grafana-values.yaml
+++ b/scripts/manifests/grafana-values.yaml
@@ -12,8 +12,8 @@ resources:
 #    cpu: "2"
 #    memory: "2000Mi"
   requests:
-    cpu: "0.2"
-    memory: "500Mi"
+    cpu: "50m"
+    memory: "250Mi"
 
 env:
   GF_DATABASE_TYPE: mysql

--- a/scripts/manifests/prometheus-operator-values.yaml
+++ b/scripts/manifests/prometheus-operator-values.yaml
@@ -1,18 +1,26 @@
 grafana:
   enabled: false
 
+alertmanager:
+  alertmanagerSpec:
+    resources:
+      requests:
+        cpu: "0m" # Added to a default of 100m
+        memory: "0Mi" # Added to a default of 25Mi
+
 prometheusOperator:
   resources:
-    limits:
-      cpu: "2"
-      memory: "8000Mi"
     requests:
-      cpu: "0.5"
-      memory: "1000Mi"
+      cpu: "50m"
+      memory: "100Mi"
 
 prometheus:
   prometheusSpec:
-    retention: 31d
+    resources:
+      requests:
+        cpu: "0m" # Added to a default of 200m
+        memory: "950Mi" # Added to a default of 50m
+    retention: 180d
     serviceMonitorNamespaceSelector:
       any: true
     storageSpec:


### PR DESCRIPTION
* Reduce humio resource requests from 0.5 CPU to 0.2 CPU and 2000MB memory to 800MB memory based on gut feeling.
* Change dev cluster size from 4 x Standard_DS1_v2 to 1 x Standard_DS2_v2.
* Reduce grafana request from 0.2 CPU to 0.05 CPU and 500MB memory to 250MB memory based on historic metrics.
* Add resource requests to alertmanager.
* Fix bug where prometheus-operator (not prometheus itself) were requesting 0.5 CPU and 1GB memory. Now gets 0.05 CPU and 100MB memory.
* Increase retention in prometheus from 30d to 180d since we now plan for longer living clusters.
* Set requests for prometheus to 0.2 CPU and 1GB of memory.

A new dev cluster installed with 1 Standard_DS2_v2 node now has ~0.7 CPU and 2.5GB memory available for actual workloads.