### PR TITLE
Allow for radix monitor to list ingresses

### DIFF
--- a/charts/radix-e2e-monitoring/Chart.yaml
+++ b/charts/radix-e2e-monitoring/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: radix-e2e-monitoring
-version: 1.0.14
-appVersion: 1.0.14
+version: 1.0.15
+appVersion: 1.0.15
 kubeVersion: ">=1.11.2"
 description: K6 continous performance tests
 keywords:

--- a/charts/radix-e2e-monitoring/templates/clusterrole.yaml
+++ b/charts/radix-e2e-monitoring/templates/clusterrole.yaml
@@ -25,4 +25,8 @@ rules:
   resources: ["configmaps"]
   verbs: ["get", "list", "watch"]
 
+- apiGroups: ["extensions"]
+  resources: ["ingresses"]
+  verbs: ["get", "list", "watch"]
+
 {{- end -}}


### PR DESCRIPTION
API server logs gets filled up because radix-monitoring have no access to ingresses in RBAC role