### PR TITLE
Check flux cli

### DIFF
--- a/scripts/flux/README.md
+++ b/scripts/flux/README.md
@@ -37,3 +37,15 @@ Teardown will
 1. Delete flux and all related custom resources
 1. Delete the repo credentials in the cluster
    -  It will _not_ touch the keyvault
+
+## Issues bootstrapping Flux
+
+If you get an error saying `unable to clone 'ssh://git@github.com/equinor/radix-flux', error: ssh: handshake failed: knownhosts: key mismatch` this means that the file `~/.ssh/known_hosts` is missing a `ecdsa-sha2-nistp256` key for `github.com`
+
+Run the following commands to fix this issue:
+1. `ssh-keyscan -t ecdsa github.com >> ~/.ssh/known_hosts` adds the new github.com key
+2. If you get a **duplicate key** warning, run `ssh-keygen -R 140.82.121.3` to remove the duplicate key
+
+References:
+- [https://github.blog/2021-09-01-improving-git-protocol-security-github/](https://github.blog/2021-09-01-improving-git-protocol-security-github/)
+- [https://github.com/fluxcd/flux2/discussions/2097](https://github.com/fluxcd/flux2/discussions/2097)

--- a/scripts/flux/bootstrap.sh
+++ b/scripts/flux/bootstrap.sh
@@ -73,6 +73,10 @@ hash helm 2>/dev/null || {
     echo -e "\nError: helm not found in PATH. Exiting..."
     exit 1
 }
+hash flux 2>/dev/null || {
+    echo -e "\nError: flux not found in PATH. Exiting..."
+    exit 1
+}
 printf "All is good."
 echo ""
 

--- a/scripts/flux/bootstrap.sh
+++ b/scripts/flux/bootstrap.sh
@@ -226,18 +226,11 @@ else
     printf "...Keys found."
 fi
 
-printf "\nCreating k8s secret \"$FLUX_PRIVATE_KEY_NAME\"..."
 az keyvault secret download \
     --vault-name $AZ_RESOURCE_KEYVAULT \
     --name "$FLUX_PRIVATE_KEY_NAME" \
     --file "$FLUX_PRIVATE_KEY_NAME" \
     2>&1 >/dev/null
-
-kubectl create secret generic "$FLUX_PRIVATE_KEY_NAME" \
-    --from-file=identity="$FLUX_PRIVATE_KEY_NAME" \
-    --dry-run=client -o yaml |
-    kubectl apply -f - \
-        2>&1 >/dev/null
 
 printf "...Done\n"
 
@@ -319,16 +312,6 @@ printf "...Done.\n"
 
 echo ""
 echo "Starting installation of Flux..."
-
-# SSH authentication requires a Kubernetes secret with identity and known_hosts fields:
-# https://fluxcd.io/docs/components/source/gitrepositories/#ssh-authentication
-ssh-keygen -q -N "" -f ./identity
-ssh-keyscan github.com > ./known_hosts 2>/dev/null
-kubectl create secret generic flux-system \
-    --from-file=./identity \
-    --from-file=./identity.pub \
-    --from-file=./known_hosts
-rm identity identity.pub known_hosts
 
 flux bootstrap git \
     --private-key-file="$FLUX_PRIVATE_KEY_NAME" \

--- a/scripts/migrate.sh
+++ b/scripts/migrate.sh
@@ -58,6 +58,10 @@ hash htpasswd 2>/dev/null || {
   echo -e "\nError: htpasswd not found in PATH. Exiting..."
   exit 1
 }
+hash flux 2>/dev/null || {
+    echo -e "\nError: flux not found in PATH. Exiting... " >&2
+    exit 1
+}
 printf "Done.\n"
 
 #######################################################################################

--- a/scripts/radix-zone/radix_zone_dev.env
+++ b/scripts/radix-zone/radix_zone_dev.env
@@ -25,7 +25,7 @@ RADIX_WEBHOOK_PREFIX="webhook-radix-github-webhook-qa"
 GIT_REPO="ssh://git@github.com/equinor/radix-flux"
 GIT_DIR="clusters/${CLUSTER_TYPE}"
 GIT_BRANCH="master"
-FLUX_VERSION="0.18.3" # flux2 version
+FLUX_VERSION="v0.23.0" # flux2 version
 
 #######################################################################################
 ### OAuth2 settings for the web console

--- a/scripts/radix-zone/radix_zone_playground.env
+++ b/scripts/radix-zone/radix_zone_playground.env
@@ -25,7 +25,7 @@ RADIX_WEBHOOK_PREFIX="webhook-radix-github-webhook-prod"
 GIT_REPO="ssh://git@github.com/equinor/radix-flux"
 GIT_DIR="clusters/${CLUSTER_TYPE}"
 GIT_BRANCH="master"
-FLUX_VERSION="0.18.3" # flux2 version
+FLUX_VERSION="v0.23.0" # flux2 version
 
 #######################################################################################
 ### OAuth2 settings for the web console

--- a/scripts/radix-zone/radix_zone_prod.env
+++ b/scripts/radix-zone/radix_zone_prod.env
@@ -25,7 +25,7 @@ RADIX_WEBHOOK_PREFIX="webhook-radix-github-webhook-prod"
 GIT_REPO="ssh://git@github.com/equinor/radix-flux"
 GIT_DIR="clusters/${CLUSTER_TYPE}"
 GIT_BRANCH="master"
-FLUX_VERSION="0.18.3" # flux2 version
+FLUX_VERSION="v0.23.0" # flux2 version
 
 #######################################################################################
 ### OAuth2 settings for the web console


### PR DESCRIPTION
- Check that flux cli is installed
- Remove unneccessary secrets in default namespace
- Fix flux version in env files. Version must be prefixed with `v`, e.g. `v0.23.0`. Without the `v` flux will install the latest. v023.0 is what  has been installed on all clusters, not 0.18.3