### PR TITLE
add script for refreshing web console app secret

### DIFF
--- a/scripts/cicd-canary/update_auth_secret.sh
+++ b/scripts/cicd-canary/update_auth_secret.sh
@@ -95,7 +95,7 @@ echo ""
 printf "Re-generate client secret for App Registration \"$APP_REGISTRATION_NAME\"..."
 APP_REGISTRATION_CLIENT_ID=$(az ad app list --display-name "$APP_REGISTRATION_NAME" | jq -r '.[].appId')
 
-UPDATED_PRIVATE_IMAGE_HUB_PASSWORD=$(az ad app credential reset --id "$APP_REGISTRATION_CLIENT_ID" --credential-description "rdx-cicd-canary" 2>/dev/null | jq -r '.password') # For some reason, description can not be too long.
+UPDATED_PRIVATE_IMAGE_HUB_PASSWORD=$(az ad app credential reset --id "$APP_REGISTRATION_CLIENT_ID" --display-name "rdx-cicd-canary" 2>/dev/null | jq -r '.password')
 if [[ -z "$UPDATED_PRIVATE_IMAGE_HUB_PASSWORD" ]]; then
     echo -e "\nERROR: Could not re-generate client secret for App Registration \"$APP_REGISTRATION_NAME\". Exiting..." >&2
     exit 1
@@ -103,7 +103,7 @@ fi
 printf " Done.\n"
 
 # Get expiration date of updated credential
-EXPIRATION_DATE=$(az ad app credential list --id $APP_REGISTRATION_CLIENT_ID --query "[?customKeyIdentifier=='rdx-cicd-canary'].endDate" --output tsv | sed 's/\..*//')"Z"
+EXPIRATION_DATE=$(az ad app credential list --id $APP_REGISTRATION_CLIENT_ID --query "[?displayName=='rdx-cicd-canary'].endDateTime" --output tsv | sed 's/\..*//')""
 # Get the existing secret and change the value using jq.
 FIRST_KEYVAULT=${KEYVAULT_LIST%%,*}
 

--- a/scripts/service-principals-and-aad-apps/README.md
+++ b/scripts/service-principals-and-aad-apps/README.md
@@ -112,14 +112,23 @@ Keep in mind the following:
    1. Delete all the running pods of the component so that k8s will redeploy them with updated k8s secret
 
 
-#### Refresh AKS credentials
+#### Refresh Radix Web Console App Credentials
 
-1. Refresh credentials for 
-   - Cluster service principal by using script [`refresh_service_principal_credentials.sh`](./refresh_service_principal_credentials.sh)
-   - Cluster AD app for RBAC integration by using script [`refresh_aad_app_credentials.sh`](./refresh_aad_app_credentials.sh)
-1. Update AKS credentials using script [`update_aks_credentials_in_cluster.sh`](./update_aks_credentials_in_cluster.sh)
+There are currently three app registrations for Radix Web Console:
+- Radix Web Console - Development Clusters
+- Radix Web Console - Playground Clusters
+- Radix Web Console - Production Clusters
 
+Each of them are used by one or multiple clusters and is defined by the OAUTH2_PROXY_CLIENT_ID variable in the zone-files.
 
+1. Decide if you need to refresh the client secret for any of the Radix Web Console app registrations.
+   Multiple clusters may use the same Radix Web Console app registration and refreshing the app secret will impact all of them.
+   - If yes to refresh the client secret in AAD:
+     Refresh client secret for Radix Web Console and store in keyvault by using script ['refresh_web_console_app_credentials.sh](./refresh_web_console_app_credentials.sh)
+1. Update the OAUTH2_CLIENT_PROXY_SECRET for Radix Web Console auth component in all clusters using the app registration
+   - Manual: Use Radix Web Console, navigate to the radix-web-console application's `auth` component and update the `OAUTH2_PROXY_CLIENT_SECRET` secret with the newly generated app secret.
+   - Script: Run [update_auth_proxy_secret_for_console.sh](./../update_auth_proxy_secret_for_console.sh) to update k8s secret for the `auth` component
+   
 
 ## Delete a service principal and related stored credentials
 

--- a/scripts/service-principals-and-aad-apps/refresh_web_console_app_credentials.sh
+++ b/scripts/service-principals-and-aad-apps/refresh_web_console_app_credentials.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+
+
+#######################################################################################
+### PURPOSE
+### 
+
+# Refresh credentials for Radix Web Console AAD app and store in keyvault
+
+#######################################################################################
+### INPUTS
+### 
+
+# Required:
+# - RADIX_ZONE_ENV      : Path to *.env file
+
+# Optional:
+# - USER_PROMPT         : Is human interaction is required to run script? true/false. Default is true.
+
+
+#######################################################################################
+### HOW TO USE
+### 
+
+# RADIX_ZONE_ENV=../radix-zone/radix_zone_dev.env ./refresh_web_console_app_credentials.sh
+
+
+#######################################################################################
+### START
+### 
+
+echo ""
+echo "Start refreshing credentials for Radix Web Console AAD app... "
+
+
+#######################################################################################
+### Check for prerequisites binaries
+###
+
+printf "Check for neccesary executables for \"$(basename ${BASH_SOURCE[0]})\"... "
+hash az 2> /dev/null || { echo -e "\nERROR: Azure-CLI not found in PATH. Exiting... " >&2;  exit 1; }
+hash jq 2> /dev/null || { echo -e "\nERROR: jq not found in PATH. Exiting... " >&2;  exit 1; }
+printf "Done.\n"
+
+
+#######################################################################################
+### Read inputs and configs
+###
+
+# Required inputs
+
+if [[ -z "$RADIX_ZONE_ENV" ]]; then
+    echo "ERROR: Please provide RADIX_ZONE_ENV" >&2
+    exit 1
+else
+    if [[ ! -f "$RADIX_ZONE_ENV" ]]; then
+        echo "ERROR: RADIX_ZONE_ENV=$RADIX_ZONE_ENV is invalid, the file does not exist." >&2
+        exit 1
+    fi
+    source "$RADIX_ZONE_ENV"
+fi
+
+if [[ -z "$USER_PROMPT" ]]; then
+    USER_PROMPT=true
+fi
+
+WEB_CONSOLE_DISPLAY_NAME=$(az ad app show --id "${OAUTH2_PROXY_CLIENT_ID}" --query displayName --output tsv) || exit
+
+#######################################################################################
+### Prepare az session
+###
+
+printf "Logging you in to Azure if not already logged in... "
+az account show >/dev/null || az login >/dev/null
+az account set --subscription "$AZ_SUBSCRIPTION_ID" >/dev/null
+printf "Done.\n"
+
+
+#######################################################################################
+### Verify task at hand
+###
+
+echo -e ""
+echo -e "Refresh credentials for Radix Web Console will use the following configuration:"
+echo -e ""
+echo -e "   > WHERE:"
+echo -e "   ------------------------------------------------------------------"
+echo -e "   -  RADIX_ZONE                               : $RADIX_ZONE"
+echo -e "   -  AZ_RESOURCE_KEYVAULT                     : $AZ_RESOURCE_KEYVAULT"
+echo -e "   -  VAULT_CLIENT_SECRET_NAME                 : $VAULT_CLIENT_SECRET_NAME"
+echo -e ""
+echo -e "   > WHAT:"
+echo -e "   -------------------------------------------------------------------"
+echo -e "   -  Radix Web Console App Name               : $WEB_CONSOLE_DISPLAY_NAME"
+echo -e ""
+echo -e "   > WHO:"
+echo -e "   -------------------------------------------------------------------"
+echo -e "   -  AZ_SUBSCRIPTION                          : $(az account show --query name -otsv)"
+echo -e "   -  AZ_USER                                  : $(az account show --query user.name -o tsv)"
+echo -e ""
+
+echo ""
+
+if [[ $USER_PROMPT == true ]]; then
+    while true; do
+        read -p "Is this correct? (Y/n) " yn
+        case $yn in
+            [Yy]* ) break;;
+            [Nn]* ) echo ""; echo "Quitting."; exit 0;;
+            * ) echo "Please answer yes or no.";;
+        esac
+    done
+fi
+
+echo ""
+
+
+#######################################################################################
+### Refresh credentials for Radix Web Console app in Azure AD and store in key vault
+###
+
+printf "Generating new app secret for ${WEB_CONSOLE_DISPLAY_NAME} in Azure AD..."
+
+password="$(az ad app credential reset --id "${OAUTH2_PROXY_CLIENT_ID}" --display-name "web console" --append --query password --output tsv)"
+secret="$(az ad app credential list --id "${OAUTH2_PROXY_CLIENT_ID}" --query "sort_by([?displayName=='web console'], &endDateTime)[-1:].{endDateTime:endDateTime,keyId:keyId}")"
+expiration_date="$(echo "${secret}" | jq -r .[].endDateTime | sed 's/\..*//')" || exit
+
+printf "Update credentials for ${WEB_CONSOLE_DISPLAY_NAME} in keyvault ${AZ_RESOURCE_KEYVAULT}..."
+
+# Upload to keyvault
+az keyvault secret set --vault-name "${AZ_RESOURCE_KEYVAULT}" --name "${VAULT_CLIENT_SECRET_NAME}" --value "${password}" --expires "${expiration_date}" --output none || exit
+
+printf "Done.\n"
+
+
+#######################################################################################
+### Explain manual steps
+###
+
+echo ""
+echo ">> You must manually update credentials for Radix Web Console in clusters."
+echo ">> See Refresh Radix Web Console App Credentials in README."
+
+
+#######################################################################################
+### END
+###

--- a/scripts/service-principals-and-aad-apps/refresh_web_console_app_credentials.sh
+++ b/scripts/service-principals-and-aad-apps/refresh_web_console_app_credentials.sh
@@ -138,7 +138,7 @@ printf "Done.\n"
 ###
 
 echo ""
-echo ">> You must manually update credentials for Radix Web Console in clusters."
+echo ">> You must update credentials for Radix Web Console in clusters."
 echo ">> See Refresh Radix Web Console App Credentials in README."
 
 

--- a/scripts/update_auth_proxy_secret_for_console.sh
+++ b/scripts/update_auth_proxy_secret_for_console.sh
@@ -9,6 +9,9 @@
 # Example 2: Using a subshell to avoid polluting parent shell
 # (RADIX_ZONE_ENV=./radix-zone/radix_zone_dev.env AUTH_PROXY_COMPONENT="auth" WEB_COMPONENT="web" WEB_CONSOLE_NAMESPACE="radix-web-console-prod" AUTH_PROXY_REPLY_PATH="/oauth2/callback" ./update_auth_proxy_secret_for_console.sh)
 #
+# Example 3: Use the .custom-domain ingress suffix when updating secrets when cluster is the active cluster
+# RADIX_ZONE_ENV=./radix-zone/radix_zone_dev.env AUTH_PROXY_COMPONENT="auth" WEB_COMPONENT="web" WEB_CONSOLE_NAMESPACE="radix-web-console-qa" AUTH_PROXY_REPLY_PATH="/oauth2/callback" AUTH_INGRESS_SUFFIX=".custom-domain" ./update_auth_proxy_secret_for_console.sh
+#
 
 # INPUTS:
 #   RADIX_ZONE_ENV          (Mandatory)


### PR DESCRIPTION
- Fixed existing scripts. "az ad ..." has switched from Azure Graph API to Microsoft Graph API. The response from MS Graph has different properties, e.g. displayName instead of customKeyIdentifier and endDateTime instead of endDate. 
endDateTime also includes timezone (2023-08-22T12:31:45Z), so the sed thingy is probably not needed? Any comments?
- Added script for generating new client secret for web console and store it in keyvault.