### PR TITLE
Enable oidc issuer when bootstrapping AKS

### DIFF
--- a/scripts/aks/bootstrap.sh
+++ b/scripts/aks/bootstrap.sh
@@ -585,6 +585,7 @@ AKS_BASE_OPTIONS=(
     --enable-addons azure-keyvault-secrets-provider
     --nodepool-name systempool
     --enable-secret-rotation
+    --enable-oidc-issuer
     --enable-cluster-autoscaler
     --node-count "2"
     --min-count "1"


### PR DESCRIPTION
Enables public OIDC issuer URL for AKS.
The public OIDC issuer URL is required by Azure AD app federations with Kubernetes