### PR TITLE
Better ACR DNS control

### DIFF
--- a/terraform/infrastructure/s940/prod/acr/acr.tf
+++ b/terraform/infrastructure/s940/prod/acr/acr.tf
@@ -41,9 +41,33 @@ resource "azurerm_private_endpoint" "acr_app" {
     is_manual_connection           = false
     subresource_names              = ["registry"]
   }
+}
 
-  private_dns_zone_group {
-    name                 = "dns-acr-app-${each.key}"
-    private_dns_zone_ids = [azurerm_private_dns_zone.zone[each.key].id]
-  }
+
+locals {
+  acrDnsRecords = flatten([
+    for key, value in var.K8S_ENVIROMENTS :
+    [
+      for ip in azurerm_private_endpoint.acr_app[key].custom_dns_configs :
+      {
+        ips : ip.ip_addresses,
+        fqdn : ip.fqdn,
+        subdomain : replace(ip.fqdn, ".azurecr.io", ""),
+        env : key
+      }
+    ]
+  ])
+}
+
+resource "azurerm_private_dns_a_record" "dns_record" {
+  # Adds a unique key to each value to use it in for_each
+  for_each = {for value in local.acrDnsRecords : join("-", [value.env, value.subdomain]) => value}
+
+  name                = each.value.subdomain
+  zone_name           = azurerm_private_dns_zone.zone[each.value.env].name
+  resource_group_name = join("", ["cluster-vnet-hub-", each.value.env])
+  ttl                 = 300
+  records             = each.value.ips
+
+  depends_on = [azurerm_private_endpoint.acr_app]
 }

--- a/terraform/infrastructure/s940/prod/acr/dns.tf
+++ b/terraform/infrastructure/s940/prod/acr/dns.tf
@@ -18,7 +18,7 @@ data "azurerm_virtual_network" "vnet" {
 resource "azurerm_private_dns_zone_virtual_network_link" "link" {
   for_each = data.azurerm_virtual_network.vnet
 
-  name                  = each.key # Cluster Name
+  name                  = "${each.key}-link" # Cluster Name
   private_dns_zone_name = "privatelink.azurecr.io"
   resource_group_name   = var.virtual_networks[local.clusterEnvironment[each.key]].rg_name
   virtual_network_id    = each.value.id

--- a/terraform/infrastructure/s940/prod/acr/pull-image-secret.tf
+++ b/terraform/infrastructure/s940/prod/acr/pull-image-secret.tf
@@ -14,7 +14,11 @@ resource "azurerm_container_registry_token_password" "password" {
 
   container_registry_token_id = azurerm_container_registry_token.app_acr[each.key].id
   password1 {
-    expiry = timeadd(plantimestamp(), var.ACR_TOKEN_LIFETIME)
+    expiry = var.ACR_TOKEN_EXPIRES_AT
+  }
+
+  lifecycle {
+    ignore_changes = [password2]
   }
 }
 
@@ -31,14 +35,12 @@ resource "azurerm_key_vault_secret" "secret" {
   key_vault_id    = data.azurerm_key_vault.vault[each.key].id
   name            = "radix-app-registry-secret-${each.key}"
   value           = azurerm_container_registry_token_password.password[each.key].password1[0].value
-  expiration_date = timeadd(plantimestamp(), var.ACR_TOKEN_LIFETIME)
+  expiration_date = formatdate("YYYY-MM-DD'T'HH:mm:ssZ", var.ACR_TOKEN_EXPIRES_AT)
   tags            = {
     "rotate-strategy" = "Manually recreate password1 in ACR, then copy secret to cluster"
     "source-token"    = "radix-app-registry-secret-${each.key}"
     "source-acr"      = azurerm_container_registry.app[each.key].name
   }
-
-  lifecycle { ignore_changes = [expiration_date] }
 }
 
 locals {
@@ -71,7 +73,7 @@ locals {
 }
 
 resource "null_resource" "create_token" {
-  triggers = { always_run = azurerm_key_vault_secret.secret[local.clusterEnvironment[each.key]].expiration_date }
+  triggers = { always_run = var.ACR_TOKEN_EXPIRES_AT }
 
   # Dont try to exec on clusters that are off, it will fail
   for_each = {for k, v in data.azurerm_kubernetes_cluster.k8s : k => v if local.nodeCount[k] > 0}
@@ -80,5 +82,4 @@ resource "null_resource" "create_token" {
     interpreter = ["/bin/bash", "-c"]
     command     = "kubectl --kubeconfig <(echo ${local.config[each.key]} | base64 --decode) apply -f <(echo ${local.secret[each.key]} | base64 --decode)"
   }
-
 }

--- a/terraform/infrastructure/s940/prod/acr/variables.tf
+++ b/terraform/infrastructure/s940/prod/acr/variables.tf
@@ -65,7 +65,7 @@ variable "key_vault_by_k8s_environment" {
   default = {}
 }
 
-variable "ACR_TOKEN_LIFETIME" {
+variable "ACR_TOKEN_EXPIRES_AT" {
   type = string
 }
 

--- a/terraform/infrastructure/s941/dev/acr/dns.tf
+++ b/terraform/infrastructure/s941/dev/acr/dns.tf
@@ -18,10 +18,10 @@ data "azurerm_virtual_network" "vnet" {
 resource "azurerm_private_dns_zone_virtual_network_link" "link" {
   for_each = data.azurerm_virtual_network.vnet
 
-  name                  = each.key # Cluster Name
+  name                  = "${each.key}-link" # Cluster Name
   private_dns_zone_name = "privatelink.azurecr.io"
   resource_group_name   = var.virtual_networks[local.clusterEnvironment[each.key]].rg_name
   virtual_network_id    = each.value.id
-  
+
   depends_on = [azurerm_container_registry.app]
 }

--- a/terraform/infrastructure/s941/dev/acr/variables.tf
+++ b/terraform/infrastructure/s941/dev/acr/variables.tf
@@ -65,7 +65,7 @@ variable "key_vault_by_k8s_environment" {
   default = {}
 }
 
-variable "ACR_TOKEN_LIFETIME" {
+variable "ACR_TOKEN_EXPIRES_AT" {
   type = string
 }
 

--- a/terraform/radix-zone/radix_zone_dev.tfvars
+++ b/terraform/radix-zone/radix_zone_dev.tfvars
@@ -22,7 +22,7 @@ CLUSTER_TYPE                   = "development"
 RADIX_ZONE                     = "dev"
 RADIX_ENVIRONMENT              = "dev"
 RADIX_WEB_CONSOLE_ENVIRONMENTS = ["qa", "prod"]
-K8S_ENVIROMENTS = {
+K8S_ENVIROMENTS                = {
   "dev"        = { "name" = "dev", "resourceGroup" = "clusters" },
   "playground" = { "name" = "playground", "resourceGroup" = "clusters" }
 }
@@ -241,7 +241,7 @@ sql_server = {
     db_admin = "radix-cost-allocation-db-admin"
     vault    = "radix-vault-dev"
     env      = "dev"
-    tags = {
+    tags     = {
       "displayName" = "SqlServer"
     }
   }
@@ -251,7 +251,7 @@ sql_server = {
     db_admin = "radix-cost-allocation-db-admin-playground"
     vault    = "radix-vault-dev"
     env      = "playground"
-    tags = {
+    tags     = {
       "displayName" = "SqlServer"
     }
   }
@@ -281,14 +281,14 @@ sql_database = {
   "sql-radix-cost-allocation-dev" = {
     name   = "sqldb-radix-cost-allocation"
     server = "sql-radix-cost-allocation-dev"
-    tags = {
+    tags   = {
       "displayName" = "Database"
     }
   }
   "sql-radix-cost-allocation-playground" = {
     name   = "sqldb-radix-cost-allocation"
     server = "sql-radix-cost-allocation-playground"
-    tags = {
+    tags   = {
       "displayName" = "Database"
     }
   }
@@ -427,4 +427,6 @@ GH_ORGANIZATION = "equinor"
 GH_REPOSITORY   = "radix-platform"
 GH_ENVIRONMENT  = "operations"
 
-ACR_TOKEN_LIFETIME = "9000h" # Aprox. 12 months
+# Update this and run terraform in acr to rotate secrets.
+# Remember to restart Operator afterwards to get refreshed tokens
+ACR_TOKEN_EXPIRES_AT = "2024-11-01T12:00:00+00:00"

--- a/terraform/radix-zone/radix_zone_prod.tfvars
+++ b/terraform/radix-zone/radix_zone_prod.tfvars
@@ -85,7 +85,8 @@ AZ_PRIVATE_DNS_ZONES = [
   "privatelink.mysql.database.azure.com",
   "privatelink.mariadb.database.azure.com",
   "privatelink.vaultcore.azure.net",
-  "private.radix.equinor.com"
+  "private.radix.equinor.com",
+  "privatelink.azurecr.io"
 ]
 
 #To do
@@ -306,7 +307,7 @@ sql_server = {
     db_admin = "radix-cost-allocation-db-admin"
     vault    = "radix-vault-c2-prod"
     env      = "c2"
-    tags = {
+    tags     = {
       "displayName" = "SqlServer"
     }
     identity = false
@@ -318,7 +319,7 @@ sql_server = {
     vault    = "radix-vault-prod"
     env      = "prod"
     sku_name = "S3"
-    tags = {
+    tags     = {
       "displayName" = "SqlServer"
     }
   }
@@ -349,7 +350,7 @@ sql_database = {
   "sql-radix-cost-allocation-c2-prod" = {
     name   = "sqldb-radix-cost-allocation"
     server = "sql-radix-cost-allocation-c2-prod"
-    tags = {
+    tags   = {
       "displayName" = "Database"
     }
   }
@@ -357,7 +358,7 @@ sql_database = {
     name     = "sqldb-radix-cost-allocation"
     server   = "sql-radix-cost-allocation-prod"
     sku_name = "S3"
-    tags = {
+    tags     = {
       "displayName" = "Database"
     }
   }
@@ -490,4 +491,6 @@ GH_ORGANIZATION = "equinor"
 GH_REPOSITORY   = "radix-platform"
 GH_ENVIRONMENT  = "operations"
 
-ACR_TOKEN_LIFETIME = "9000h" # Aprox. 12 months
+# Update this and run terraform in acr to rotate secrets.
+# Remember to restart Operator afterwards to get refreshed tokens
+ACR_TOKEN_EXPIRES_AT = "2024-11-01T12:00:00+00:00"


### PR DESCRIPTION
Notes:
- `azurerm_private_dns_zone_virtual_network_link` have had the wrong names compared to the script... I have updated TF to match the scrip-generated name (included a `-link` suffix)
- Needs to be run twice, once to remove legacy DNS, once to add our controlled DNS
