### PR TITLE
remove "Application Developer" role check

### DIFF
--- a/scripts/service-principals-and-aad-apps/refresh_aad_app_credentials.sh
+++ b/scripts/service-principals-and-aad-apps/refresh_aad_app_credentials.sh
@@ -106,8 +106,6 @@ az account show >/dev/null || az login >/dev/null
 az account set --subscription "$AZ_SUBSCRIPTION_ID" >/dev/null
 printf "Done.\n"
 
-exit_if_user_does_not_have_required_ad_role
-
 #######################################################################################
 ### Verify task at hand
 ###


### PR DESCRIPTION
"Application Developer" role is not required to create a new app secret.