### PR TITLE
Bootstrap flux secrets for installing Lets Encrypt issuer

### DIFF
--- a/scripts/cert-manager/bootstrap.sh
+++ b/scripts/cert-manager/bootstrap.sh
@@ -195,6 +195,16 @@ kubectl create namespace cert-manager \
 
 # Create secret for flux
 
+# TODO: Remove boostrap of cert-manager-helm-secret secret
+echo "ingressShim:
+  defaultIssuerName: ${CERT_ISSUER}
+  defaultIssuerKind: ClusterIssuer" > config
+kubectl create secret generic cert-manager-helm-secret --namespace cert-manager \
+    --from-file=./config \
+    --dry-run=client -o yaml |
+    kubectl apply -f -
+rm -f config
+
 DNS_SP="$(az keyvault secret show \
     --vault-name $AZ_RESOURCE_KEYVAULT \
     --name $APP_REGISTRATION_CERT_MANAGER \

--- a/scripts/cert-manager/bootstrap.sh
+++ b/scripts/cert-manager/bootstrap.sh
@@ -92,11 +92,6 @@ if [[ -z "$CLUSTER_NAME" ]]; then
     exit 1
 fi
 
-if [[ -z "$RADIX_WILDCARD_CERTIFICATE_ISSUER" ]]; then
-    echo "ERROR: Please provide RADIX_WILDCARD_CERTIFICATE_ISSUER" >&2
-    exit 1
-fi
-
 # Source util scripts
 
 source ${RADIX_PLATFORM_REPOSITORY_PATH}/scripts/utility/util.sh
@@ -149,7 +144,6 @@ echo -e ""
 echo -e "   > WHAT:"
 echo -e "   -------------------------------------------------------------------"
 echo -e "   -  CERT_ISSUER                       : $CERT_ISSUER"
-echo -e "   -  RADIX_WILDCARD_CERTIFICATE_ISSUER : $RADIX_WILDCARD_CERTIFICATE_ISSUER"
 echo -e ""
 echo -e "   > WHO:"
 echo -e "   -------------------------------------------------------------------"
@@ -221,7 +215,6 @@ metadata:
 type: Opaque
 stringData:
   CERT_ISSUER: ${CERT_ISSUER}
-  RADIX_WILDCARD_CERTIFICATE_ISSUER: ${RADIX_WILDCARD_CERTIFICATE_ISSUER}
   AZ_RESOURCE_DNS: ${AZ_RESOURCE_DNS}
   ACME_URL: ${ACME_URL}
   DNS_SP_ID: ${DNS_SP_ID}

--- a/scripts/cert-manager/cluster-issuers/digicert/bootstrap.sh
+++ b/scripts/cert-manager/cluster-issuers/digicert/bootstrap.sh
@@ -171,7 +171,7 @@ cat <<EOF | kubectl apply -f - || exit
 apiVersion: v1
 kind: Secret
 metadata:
-  name: digicert-clusterissuer-external-account-flux-values
+  name: digicert-clusterissuer-flux-values
   namespace: flux-system
 type: Opaque
 stringData:

--- a/scripts/cert-manager/cluster-issuers/letsencrypt/README.md
+++ b/scripts/cert-manager/cluster-issuers/letsencrypt/README.md
@@ -1,0 +1,11 @@
+# Lets Encrypt cluster issuer
+
+Scripts for managing secrets required by Flux to install Lets Encrypt cluster issuers.
+
+## Bootstrap
+
+Run script [`./bootstrap.sh`](./bootstrap.sh), see script header for more how.  
+
+Bootstrap will
+1. Create a Kubernetes secret with info required by Flux to install ACME cluster DNS01 issuer for Lets Encrypt
+

--- a/scripts/install_base_components.sh
+++ b/scripts/install_base_components.sh
@@ -263,6 +263,15 @@ printf "%s► Execute %s%s\n" "${grn}" "$WORKDIR_PATH/scripts/cert-manager/clust
 wait
 
 #######################################################################################
+### Install Lets Encrypt issuer values for Flux
+###
+
+echo ""
+printf "%s► Execute %s%s\n" "${grn}" "$WORKDIR_PATH/scripts/cert-manager/cluster-issuers/letsencrypt/bootstrap.sh" "${normal}"
+(USER_PROMPT="$USER_PROMPT" ./cert-manager/cluster-issuers/letsencrypt/bootstrap.sh)
+wait
+
+#######################################################################################
 ### Create storage classes
 ###
 

--- a/scripts/radix-zone/radix_zone_c2.env
+++ b/scripts/radix-zone/radix_zone_c2.env
@@ -246,6 +246,5 @@ RADIX_ERROR_PAGE=equinorcom_error_page.html
 ### Cert Manager
 ###
 
-RADIX_WILDCARD_CERTIFICATE_ISSUER=letsencrypt-dns01
 LETS_ENCRYPT_ACME_ACCOUNT_EMAIL=Radix@StatoilSRM.onmicrosoft.com
 DIGICERT_EXTERNAL_ACCOUNT_KV_SECRET="digicert-external-account-${RADIX_ZONE}-${RADIX_ENVIRONMENT}"

--- a/scripts/radix-zone/radix_zone_c2.env
+++ b/scripts/radix-zone/radix_zone_c2.env
@@ -116,7 +116,6 @@ MI_AKSKUBELET="id-radix-akskubelet-${RADIX_ZONE}-${RADIX_ENVIRONMENT}"
 ###
 
 KV_SECRET_SLACK_WEBHOOK="slack-webhook-${RADIX_ZONE}-${RADIX_ENVIRONMENT}"
-DIGICERT_EXTERNAL_ACCOUNT_KV_SECRET="digicert-external-account-${RADIX_ZONE}-${RADIX_ENVIRONMENT}"
 
 KV_EXPIRATION_TIME="12 months"
 
@@ -242,3 +241,11 @@ APP_REGISTRATION_LOG_API="ar-radix-log-api-${RADIX_ZONE}-${RADIX_ENVIRONMENT}"
 ###
 
 RADIX_ERROR_PAGE=equinorcom_error_page.html
+
+#######################################################################################
+### Cert Manager
+###
+
+RADIX_WILDCARD_CERTIFICATE_ISSUER=letsencrypt-dns01
+LETS_ENCRYPT_ACME_ACCOUNT_EMAIL=Radix@StatoilSRM.onmicrosoft.com
+DIGICERT_EXTERNAL_ACCOUNT_KV_SECRET="digicert-external-account-${RADIX_ZONE}-${RADIX_ENVIRONMENT}"

--- a/scripts/radix-zone/radix_zone_dev.env
+++ b/scripts/radix-zone/radix_zone_dev.env
@@ -251,6 +251,5 @@ RADIX_ERROR_PAGE=radix_error_page.html
 ### Cert Manager
 ###
 
-RADIX_WILDCARD_CERTIFICATE_ISSUER=letsencrypt-dns01
 LETS_ENCRYPT_ACME_ACCOUNT_EMAIL=Radix@StatoilSRM.onmicrosoft.com
 DIGICERT_EXTERNAL_ACCOUNT_KV_SECRET="digicert-external-account-$RADIX_ZONE"

--- a/scripts/radix-zone/radix_zone_dev.env
+++ b/scripts/radix-zone/radix_zone_dev.env
@@ -122,7 +122,6 @@ MI_GITHUB_MAINTENANCE="radix-github-maintenance"
 ###
 
 KV_SECRET_SLACK_WEBHOOK="slack-webhook-$RADIX_ZONE"
-DIGICERT_EXTERNAL_ACCOUNT_KV_SECRET="digicert-external-account-$RADIX_ZONE"
 
 KV_EXPIRATION_TIME="12 months"
 
@@ -247,3 +246,11 @@ APP_REGISTRATION_LOG_API="ar-radix-log-api-${RADIX_ZONE}-${RADIX_ENVIRONMENT}"
 ###
 
 RADIX_ERROR_PAGE=radix_error_page.html
+
+#######################################################################################
+### Cert Manager
+###
+
+RADIX_WILDCARD_CERTIFICATE_ISSUER=letsencrypt-dns01
+LETS_ENCRYPT_ACME_ACCOUNT_EMAIL=Radix@StatoilSRM.onmicrosoft.com
+DIGICERT_EXTERNAL_ACCOUNT_KV_SECRET="digicert-external-account-$RADIX_ZONE"

--- a/scripts/radix-zone/radix_zone_playground.env
+++ b/scripts/radix-zone/radix_zone_playground.env
@@ -119,7 +119,6 @@ MI_CERT_MANAGER="id-radix-certmanager-${CLUSTER_TYPE}-northeurope"
 ###
 
 KV_SECRET_SLACK_WEBHOOK="slack-webhook-$RADIX_ZONE"
-DIGICERT_EXTERNAL_ACCOUNT_KV_SECRET="digicert-external-account-$RADIX_ZONE"
 
 KV_EXPIRATION_TIME="12 months"
 
@@ -244,3 +243,11 @@ APP_REGISTRATION_LOG_API="ar-radix-log-api-${RADIX_ZONE}-${RADIX_ENVIRONMENT}"
 ###
 
 RADIX_ERROR_PAGE=radix_error_page.html
+
+#######################################################################################
+### Cert Manager
+###
+
+RADIX_WILDCARD_CERTIFICATE_ISSUER=letsencrypt-dns01
+LETS_ENCRYPT_ACME_ACCOUNT_EMAIL=Radix@StatoilSRM.onmicrosoft.com
+DIGICERT_EXTERNAL_ACCOUNT_KV_SECRET="digicert-external-account-$RADIX_ZONE"

--- a/scripts/radix-zone/radix_zone_playground.env
+++ b/scripts/radix-zone/radix_zone_playground.env
@@ -248,6 +248,5 @@ RADIX_ERROR_PAGE=radix_error_page.html
 ### Cert Manager
 ###
 
-RADIX_WILDCARD_CERTIFICATE_ISSUER=letsencrypt-dns01
 LETS_ENCRYPT_ACME_ACCOUNT_EMAIL=Radix@StatoilSRM.onmicrosoft.com
 DIGICERT_EXTERNAL_ACCOUNT_KV_SECRET="digicert-external-account-$RADIX_ZONE"

--- a/scripts/radix-zone/radix_zone_prod.env
+++ b/scripts/radix-zone/radix_zone_prod.env
@@ -252,6 +252,5 @@ RADIX_ERROR_PAGE=radix_error_page.html
 ### Cert Manager
 ###
 
-RADIX_WILDCARD_CERTIFICATE_ISSUER=letsencrypt-dns01
 LETS_ENCRYPT_ACME_ACCOUNT_EMAIL=Radix@StatoilSRM.onmicrosoft.com
 DIGICERT_EXTERNAL_ACCOUNT_KV_SECRET="digicert-external-account-$RADIX_ZONE"

--- a/scripts/radix-zone/radix_zone_prod.env
+++ b/scripts/radix-zone/radix_zone_prod.env
@@ -121,7 +121,6 @@ MI_CERT_MANAGER="id-radix-certmanager-${CLUSTER_TYPE}-northeurope"
 ###
 
 KV_SECRET_SLACK_WEBHOOK="slack-webhook-$RADIX_ZONE"
-DIGICERT_EXTERNAL_ACCOUNT_KV_SECRET="digicert-external-account-$RADIX_ZONE"
 
 KV_EXPIRATION_TIME="12 months"
 
@@ -248,3 +247,11 @@ APP_REGISTRATION_LOG_API="ar-radix-log-api-${RADIX_ZONE}-${RADIX_ENVIRONMENT}"
 ###
 
 RADIX_ERROR_PAGE=radix_error_page.html
+
+#######################################################################################
+### Cert Manager
+###
+
+RADIX_WILDCARD_CERTIFICATE_ISSUER=letsencrypt-dns01
+LETS_ENCRYPT_ACME_ACCOUNT_EMAIL=Radix@StatoilSRM.onmicrosoft.com
+DIGICERT_EXTERNAL_ACCOUNT_KV_SECRET="digicert-external-account-$RADIX_ZONE"


### PR DESCRIPTION
Bootstrap secrets required by Flux to install Lets Encrypt cluster issuer and the wildcard certificate.
This is part decoupling cert-manager and cluster issuer kustomization, ref PR https://github.com/equinor/radix-flux/pull/1776