### PR TITLE
add fedcred for repo radix-buildkit-builder to MIs radix-id-acr-workflows

### DIFF
--- a/terraform/subscriptions/s940/c2/common/main.tf
+++ b/terraform/subscriptions/s940/c2/common/main.tf
@@ -135,6 +135,11 @@ module "radix-id-acr-workflows" {
       issuer  = "https://token.actions.githubusercontent.com"
       subject = "repo:equinor/radix-job-scheduler:ref:refs/heads/release"
     },
+    radix-buildkit-builder-release = {
+      name    = "radix-buildkit-builder-release"
+      issuer  = "https://token.actions.githubusercontent.com"
+      subject = "repo:equinor/radix-buildkit-builder:ref:refs/heads/release"
+    },
   }
 }
 

--- a/terraform/subscriptions/s940/prod/common/main.tf
+++ b/terraform/subscriptions/s940/prod/common/main.tf
@@ -133,6 +133,11 @@ module "radix-id-acr-workflows" {
       issuer  = "https://token.actions.githubusercontent.com"
       subject = "repo:equinor/radix-job-scheduler:ref:refs/heads/release"
     },
+    radix-buildkit-builder-release = {
+      name    = "radix-buildkit-builder-release"
+      issuer  = "https://token.actions.githubusercontent.com"
+      subject = "repo:equinor/radix-buildkit-builder:ref:refs/heads/release"
+    },
   }
 }
 

--- a/terraform/subscriptions/s941/dev/common/main.tf
+++ b/terraform/subscriptions/s941/dev/common/main.tf
@@ -128,6 +128,11 @@ module "radix-id-acr-workflows" {
       issuer  = "https://token.actions.githubusercontent.com"
       subject = "repo:equinor/radix-job-scheduler:ref:refs/heads/main"
     },
+    radix-buildkit-builder-main = {
+      name    = "radix-buildkit-builder-main"
+      issuer  = "https://token.actions.githubusercontent.com"
+      subject = "repo:equinor/radix-buildkit-builder:ref:refs/heads/main"
+    },
   }
 }
 

--- a/terraform/subscriptions/s941/playground/common/main.tf
+++ b/terraform/subscriptions/s941/playground/common/main.tf
@@ -128,6 +128,11 @@ module "radix-id-acr-workflows" {
       issuer  = "https://token.actions.githubusercontent.com"
       subject = "repo:equinor/radix-job-scheduler:ref:refs/heads/release"
     },
+    radix-buildkit-builder-release = {
+      name    = "radix-buildkit-builder-release"
+      issuer  = "https://token.actions.githubusercontent.com"
+      subject = "repo:equinor/radix-buildkit-builder:ref:refs/heads/release"
+    },
   }
 }
 


### PR DESCRIPTION
WIll be used by github action in https://github.com/equinor/radix-buildkit-builder to build and push images to Radix container registries