### PR TITLE
Ignore data_persistence_authentication_method (not used)

### DIFF
--- a/terraform/subscriptions/modules/redis_cache/main.tf
+++ b/terraform/subscriptions/modules/redis_cache/main.tf
@@ -8,12 +8,15 @@ resource "azurerm_redis_cache" "this" {
   sku_name                      = var.sku_name
   minimum_tls_version           = "1.2"
   public_network_access_enabled = false
+  lifecycle {
+    ignore_changes = [
+      redis_configuration[0].data_persistence_authentication_method
+    ]
+  }
   redis_configuration {
-    maxmemory_reserved                     = 125
-    maxmemory_delta                        = 125
-    maxfragmentationmemory_reserved        = 125
-    data_persistence_authentication_method = "SAS"
-
-    maxmemory_policy = "volatile-lru"
+    maxmemory_reserved              = 125
+    maxmemory_delta                 = 125
+    maxfragmentationmemory_reserved = 125
+    maxmemory_policy                = "volatile-lru"
   }
 }


### PR DESCRIPTION
- [ ] Do a terraform plan on current branch on the ./radix-platform/terraform/subscriptions/s9401/c2/pre-clusters
- [ ] Do a terraform plan on current branch on the ./radix-platform/terraform/subscriptions/s9401/prod/pre-clusters

Expected result:
- Apply current volatile-lru (Maxmemory policy) - No actual change as its currently use "volatile-lru" on default
- Apply Private Endpoint to Redis cache (QA-PRO) - Monitor this