### PR TITLE
fix: change vm type for gpu nodes

### DIFF
--- a/terraform/subscriptions/s940/c2/pre-clusters/.terraform.lock.hcl
+++ b/terraform/subscriptions/s940/c2/pre-clusters/.terraform.lock.hcl
@@ -40,22 +40,3 @@ provider "registry.terraform.io/hashicorp/azurerm" {
     "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
   ]
 }
-
-provider "registry.terraform.io/hashicorp/http" {
-  version = "3.4.5"
-  hashes = [
-    "h1:ceAVZEuaQd7jQX13qf5w7hy3ioiXpuwUaaDRsnAiMLM=",
-    "zh:2072006c177efc101471f3d5eb8e1d8e6c68778cbfd6db3d3f22f59cfe6ce6ae",
-    "zh:3ac4cc0efe11ee054300769cfcc37491433937a8824621d1f8f7a18e7401da87",
-    "zh:63997e5457c9ddf9cfff17bd7bf9f083cbeff3105452045662109dd6be499ef9",
-    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:826819bb8ab7d6e3095f597083d5b1ab93d1854312b9e1b6c18288fff9664f34",
-    "zh:8ad74e7d8ec2e226a73d49c7c317108f61a4cb803972fb3f945d1709d5115fcd",
-    "zh:a609ca9e0c91d250ac80295e39d5f524e8c0872d33ba8fde3c3e41893b4b015d",
-    "zh:ae07d19babc452f63f6a6511b944990e819dc20687b6c8f01d1676812f5ada53",
-    "zh:b7c827dc32a1a5d77185a78cd391b01217894b384f58169f98a96d683730d8ce",
-    "zh:d045e3db9f5e39ce78860d3fd94e04604fcbe246f6fe346ee50a971f936e9ccd",
-    "zh:ec28f9b52c74edd47eebbb5c254a6df5706360cde5ccd65097976efca23a2977",
-    "zh:f24982eaa7d34fd66554c3cf94873713a0dff14da9ea4c4be0cc76f1a6146d59",
-  ]
-}

--- a/terraform/subscriptions/s940/c2/pre-clusters/variables.tf
+++ b/terraform/subscriptions/s940/c2/pre-clusters/variables.tf
@@ -39,7 +39,7 @@ variable "nodepools" {
       node_taints = ["radix-nodetype=memory-optimized-2-v1:NoSchedule"]
     }
     nvidia1v1 = {
-      vm_size    = "Standard_NC24ads_A100_v4"
+      vm_size    = "Standard_NC40ads_H100_v5"
       min_count  = 0
       max_count  = 1
       node_count = 0
@@ -50,7 +50,7 @@ variable "nodepools" {
       os_disk_type = "Ephemeral"
     }
     nc6sv3 = {
-      vm_size    = "Standard_NC24ads_A100_v4"
+      vm_size    = "Standard_NC40ads_H100_v5"
       min_count  = 0
       max_count  = 1
       node_count = 0

--- a/terraform/subscriptions/s940/prod/pre-clusters/variables.tf
+++ b/terraform/subscriptions/s940/prod/pre-clusters/variables.tf
@@ -39,7 +39,7 @@ variable "nodepools" {
       node_taints = ["radix-nodetype=memory-optimized-2-v1:NoSchedule"]
     }
     nvidia1v1 = {
-      vm_size    = "Standard_NC24ads_A100_v4"
+      vm_size    = "Standard_NC40ads_H100_v5"
       min_count  = 0
       max_count  = 1
       node_count = 0
@@ -50,7 +50,7 @@ variable "nodepools" {
       os_disk_type = "Ephemeral"
     }
     nc6sv3 = {
-      vm_size    = "Standard_NC24ads_A100_v4"
+      vm_size    = "Standard_NC40ads_H100_v5"
       min_count  = 0
       max_count  = 1
       node_count = 0

--- a/terraform/subscriptions/s941/playground/pre-clusters/.terraform.lock.hcl
+++ b/terraform/subscriptions/s941/playground/pre-clusters/.terraform.lock.hcl
@@ -40,23 +40,3 @@ provider "registry.terraform.io/hashicorp/azurerm" {
     "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
   ]
 }
-
-provider "registry.terraform.io/hashicorp/kubernetes" {
-  version     = "2.37.1"
-  constraints = ">= 2.33.0"
-  hashes = [
-    "h1:qo9Ue/rIEnvxOpiK9qizwRFV7rvb5gCziKVytIcZHyk=",
-    "zh:0ed097413c7fc804479e325966886b405dc0b75ad2b4f54ce4df1d8e4802b397",
-    "zh:17dcf4a685a00d2d048671124e8a1a8e836b58ecd2ef628a1c666fe0ced2e598",
-    "zh:36891284e5bced57c438f12d0b27856b0d4b70b562bd200b01919a6a89545be9",
-    "zh:3e49d86b508e641ba122d1b0af24cdc4d8ffa2ec1b30022436fb1d7c6ba696ea",
-    "zh:40be623e116708bdcb0fac32989db43720f031c5fe9a4dc63395078185d24403",
-    "zh:44fc0ac3bc39e289b67f9dde7ee9fef29eb8192197e5e68fee69098573021722",
-    "zh:957aa451573bcde5d57f6f8338ea3139010c7f61fefe8f6a140a8c267f056511",
-    "zh:c55fd85b7e8acaac17e30670ac3574b88b3530820dd004bcd2a5daa8624a46e9",
-    "zh:c743f06843a1f5ecde2b8ef639f4d3db654a334ef248dee57261c719ea843f3a",
-    "zh:c93cc71c64b838d89522ac5fb60f68e0e1e7f2fc39db6b0ead7afd78795e79ed",
-    "zh:eda1163c2266905adc54bc78cc3e7b606a164fbc6b59be607db933b302015ccd",
-    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
-  ]
-}

--- a/terraform/subscriptions/s941/playground/pre-clusters/variables.tf
+++ b/terraform/subscriptions/s941/playground/pre-clusters/variables.tf
@@ -40,7 +40,7 @@ variable "nodepools" {
       node_taints = ["radix-nodetype=memory-optimized-2-v1:NoSchedule"]
     }
     nvidia1v1 = {
-      vm_size    = "Standard_NC24ads_A100_v4"
+      vm_size    = "Standard_NC40ads_H100_v5"
       min_count  = 0
       max_count  = 1
       node_count = 0
@@ -51,7 +51,7 @@ variable "nodepools" {
       os_disk_type = "Ephemeral"
     }
     nc6sv3 = {
-      vm_size    = "Standard_NC24ads_A100_v4"
+      vm_size    = "Standard_NC40ads_H100_v5"
       min_count  = 0
       max_count  = 1
       node_count = 0


### PR DESCRIPTION
Standard_NC24ads_A100_v4 is not available in North Europe. MS recommended to change to Standard_NC40ads_H100_v5