### PR TITLE
fix: remove public IP retrieval logic from flux bootstrap, migrate, and zone_new scripts

### DIFF
--- a/scripts/flux/bootstrap.sh
+++ b/scripts/flux/bootstrap.sh
@@ -301,26 +301,6 @@ printf "...Done\n"
 # Create ConfigMap radix-flux-config which will provide values for flux deployments
 echo "Creating \"radix-flux-config\"..."
 
-# list of public ips assigned to the cluster
-printf "\nGetting list of public ips assigned to $CLUSTER_NAME..."
-ASSIGNED_IPS="$(az network public-ip list \
-    --query "[?ipConfiguration.resourceGroup=='MC_${AZ_RESOURCE_GROUP_CLUSTERS}_${CLUSTER_NAME}_${AZ_RADIX_ZONE_LOCATION}'].ipAddress" \
-    --output json)"
-
-if [[ "$ASSIGNED_IPS" == "[]" ]]; then
-    echo "ERROR: Could not find Public IP of cluster." >&2
-else
-    # Loop through list of IPs and create a comma separated string.
-    for ipaddress in $(echo $ASSIGNED_IPS | jq -cr '.[]'); do
-        if [[ -z $IP_LIST ]]; then
-            IP_LIST=$(echo $ipaddress)
-        else
-            IP_LIST="$IP_LIST,$(echo $ipaddress)"
-        fi
-    done
-    printf "...Done\n"
-fi
-
 printf "\nGetting Slack Webhook URL..."
 SLACK_WEBHOOK_URL="$(az keyvault secret show --vault-name $AZ_RESOURCE_KEYVAULT --name slack-webhook | jq -r .value)"
 printf "...Done\n"
@@ -342,7 +322,6 @@ data:
   imageRegistry: "$IMAGE_REGISTRY"
   clusterName: "$CLUSTER_NAME"
   clusterType: "$CLUSTER_TYPE"
-  activeClusterIPs: "$IP_LIST"
   slackWebhookURL: "$SLACK_WEBHOOK_URL"
 EOF
 

--- a/scripts/migrate.sh
+++ b/scripts/migrate.sh
@@ -425,26 +425,6 @@ if [[ $install_base_components == true ]]; then
 
     echo "Creating \"radix-flux-config\"..."
 
-    # list of public ips assigned to the cluster
-    printf "\nGetting list of public ips assigned to $CLUSTER_NAME..."
-    ASSIGNED_IPS="$(az network public-ip list \
-        --query "[?ipConfiguration.resourceGroup=='MC_${AZ_RESOURCE_GROUP_CLUSTERS}_${CLUSTER_NAME}_${AZ_RADIX_ZONE_LOCATION}'].ipAddress" \
-        --output json)"
-
-    if [[ "$ASSIGNED_IPS" == "[]" ]]; then
-        echo "ERROR: Could not find Public IP of cluster." >&2
-    else
-        # Loop through list of IPs and create a comma separated string.
-        for ipaddress in $(echo $ASSIGNED_IPS | jq -cr '.[]'); do
-            if [[ -z $IP_LIST ]]; then
-                IP_LIST=$(echo $ipaddress)
-            else
-                IP_LIST="$IP_LIST,$(echo $ipaddress)"
-            fi
-        done
-        printf "...Done\n"
-    fi
-
     printf "\nGetting Slack Webhook URL..."
     SLACK_WEBHOOK_URL="$(az keyvault secret show --vault-name $AZ_RESOURCE_KEYVAULT --name slack-webhook | jq -r .value)"
     printf "...Done\n"
@@ -464,7 +444,6 @@ if [[ $install_base_components == true ]]; then
         --from-literal=imageRegistry="$IMAGE_REGISTRY" \
         --from-literal=clusterName="$CLUSTER_NAME" \
         --from-literal=clusterType="$(yq '.cluster_type' <<< "$RADIX_ZONE_YAML")" \
-        --from-literal=activeClusterIPs="$IP_LIST" \
         --from-literal=slackWebhookURL="$SLACK_WEBHOOK_URL"
     printf "...Done.\n"
 

--- a/scripts/zone_new.sh
+++ b/scripts/zone_new.sh
@@ -114,25 +114,6 @@ FLUX_PRIVATE_KEY="$(az keyvault secret show --name "$FLUX_PRIVATE_KEY_NAME" --va
 
 echo "Creating \"radix-flux-config\"..."
 
-# list of public ips assigned to the cluster
-printf "\nGetting list of public ips assigned to $CLUSTER_NAME..."
-ASSIGNED_IPS="$(az network public-ip list \
-    --query "[?ipConfiguration.resourceGroup=='MC_${AZ_RESOURCE_GROUP_CLUSTERS}_${CLUSTER_NAME}_${AZ_RADIX_ZONE_LOCATION}'].ipAddress" \
-    --output json)"
-
-if [[ "$ASSIGNED_IPS" == "[]" ]]; then
-    echo "ERROR: Could not find Public IP of cluster." >&2
-else
-    # Loop through list of IPs and create a comma separated string.
-    for ipaddress in $(echo $ASSIGNED_IPS | jq -cr '.[]'); do
-        if [[ -z $IP_LIST ]]; then
-            IP_LIST=$(echo $ipaddress)
-        else
-            IP_LIST="$IP_LIST,$(echo $ipaddress)"
-        fi
-    done
-    printf "...Done\n"
-fi
 printf "\nGetting Slack Webhook URL..."
 SLACK_WEBHOOK_URL="$(az keyvault secret show --vault-name $AZ_RESOURCE_KEYVAULT --name slack-webhook | jq -r .value)"
 printf "...Done\n"
@@ -151,7 +132,6 @@ kubectl create configmap radix-flux-config -n flux-system \
     --from-literal=imageRegistry="$IMAGE_REGISTRY" \
     --from-literal=clusterName="$CLUSTER_NAME" \
     --from-literal=clusterType="$(yq '.cluster_type' <<< "$RADIX_ZONE_YAML")" \
-    --from-literal=activeClusterIPs="$IP_LIST" \
     --from-literal=slackWebhookURL="$SLACK_WEBHOOK_URL"
 printf "...Done.\n"
 


### PR DESCRIPTION
This pull request removes all logic and configuration related to retrieving and storing the list of public IPs assigned to a cluster in the `radix-flux-config` ConfigMap. This value was removed from radix-flux in [this PR](https://github.com/equinor/radix-flux/pull/3021)
