### PR TITLE
New weekly.

### DIFF
--- a/scripts/velero/restore/restore_apps.sh
+++ b/scripts/velero/restore/restore_apps.sh
@@ -269,7 +269,7 @@ stop_radix_operator() {
   kubectl scale deployment radix-operator --namespace default --replicas=0
 
   printf "Waiting for radix-operator is stopped\n"
-  while [[ $(kubectl get pods --selector='app.kubernetes.io/name=radix-operator' --namespace default | wc -l) != 0 ]]; do
+  while [[ $(kubectl get pods --selector='app.kubernetes.io/name=radix-operator' --namespace default -o name | wc -l) -ne 0 ]]; do
     sleep 5
   done
   printf " Done.\n"
@@ -280,7 +280,7 @@ start_radix_operator() {
   kubectl scale deployment radix-operator --namespace default --replicas=1
 
   printf "Waiting for radix-operator is started"
-  while [[ $(kubectl get pods --selector='app.kubernetes.io/name=radix-operator' --namespace default | wc -l) == 0 ]]; do
+  while [[ $(kubectl get pods --selector='app.kubernetes.io/name=radix-operator' --namespace default -o name | wc -l) -eq 0 ]]; do
     sleep 5
   done
   printf " Done.\n"

--- a/terraform/subscriptions/s941/dev/config.yaml
+++ b/terraform/subscriptions/s941/dev/config.yaml
@@ -41,12 +41,12 @@ clusters:
     network_policy: "cilium"
     hostencryption: true
     dns_wildcard: nginx # Options: "nginx" or "istio"
-    activecluster: true
+    #activecluster: true
 
-  weekly-03:
+  weekly-05:
     aksversion: "1.33.5"
     networkset: "networkset2"
     network_policy: "cilium"
     hostencryption: true
     dns_wildcard: nginx # Options: "nginx" or "istio"
-    # activecluster: true
+    activecluster: true


### PR DESCRIPTION
Scripts was incompatible with Mac. Mac's "wc" tool outputs in table format, leaving padding that messed up the string comparison.