### PR TITLE
Revert cluster_type terraform workaround

### DIFF
--- a/terraform/subscriptions/s941/playground/config.yaml
+++ b/terraform/subscriptions/s941/playground/config.yaml
@@ -1,7 +1,6 @@
 environment: "playground"
 flux_folder: "playground"
-# cluster_type: "playground"
-cluster_type: "development"
+cluster_type: "playground"
 subscription_shortname: "s941"
 location: "northeurope"
 developers: ["bed2b667-ceec-4377-83f7-46888ed23887"] # AZ PIM OMNIA RADIX Cluster Admin - dev


### PR DESCRIPTION
Revert cluster_type in playground, due to a previous fix in terraform to limit SKU on resources. Need to make a new branch to fix the issue