### PR TITLE
feat: enhance update_account.sh to read environment variables from terraform and set secret expiry

### DIFF
--- a/scripts/cert-manager/cluster-issuers/digicert/update_account.sh
+++ b/scripts/cert-manager/cluster-issuers/digicert/update_account.sh
@@ -105,7 +105,7 @@ source ${RADIX_PLATFORM_REPOSITORY_PATH}/scripts/utility/util.sh
 #######################################################################################
 ### Environment
 ###
-printf "\n► Read YAML configfile $RADIX_ZONE"
+printf "\n► Read YAML config file $RADIX_ZONE"
 RADIX_ZONE_ENV=$(config_path $RADIX_ZONE)
 printf "\n► Read terraform variables and configuration"
 RADIX_RESOURCE_JSON=$(environment_json $RADIX_ZONE)


### PR DESCRIPTION
This script is referenced in the digicert documentation in radix-private