### PR TITLE
Refactor Storageaccounts

### DIFF
--- a/terraform/subscriptions/modules/storageaccount/main.tf
+++ b/terraform/subscriptions/modules/storageaccount/main.tf
@@ -148,55 +148,30 @@ resource "azurerm_private_dns_a_record" "this" {
 ##
 
 resource "azurerm_storage_management_policy" "this" {
+  count              = length(var.lifecycle_policy_rules) > 0 ? 1 : 0
   storage_account_id = azurerm_storage_account.storageaccount.id
+
   dynamic "rule" {
-    for_each = (!var.testzone && var.cluster_type == "production" && strcontains(var.name, "velero")) ? [1] : []
+    for_each = var.lifecycle_policy_rules
     content {
-      name    = "Lifecycle Storageaccount"
-      enabled = true
+      name    = rule.value.name
+      enabled = rule.value.enabled
       filters {
-        blob_types = ["blockBlob", "appendBlob"]
+        blob_types = rule.value.blob_types
       }
       actions {
-        version {
-          delete_after_days_since_creation = 60
+        dynamic "version" {
+          for_each = rule.value.delete_after_days_since_creation == null ? [] : [rule.value.delete_after_days_since_creation]
+          content {
+            delete_after_days_since_creation = version.value
+          }
         }
-        base_blob {
-          delete_after_days_since_modification_greater_than = 90
-        }
-      }
-    }
-  }
-  dynamic "rule" {
-    for_each = (!var.testzone && var.cluster_type == "production") && strcontains(var.name, "log") ? [1] : []
-    content {
-      name    = "Lifecycle Storageaccount"
-      enabled = true
-      filters {
-        blob_types = ["blockBlob"]
-      }
-      actions {
-        version {
-          delete_after_days_since_creation = 60
-        }
-        base_blob {
-          delete_after_days_since_modification_greater_than       = 90
-          tier_to_cool_after_days_since_modification_greater_than = 30
-        }
-      }
-    }
-  }
-  dynamic "rule" {
-    for_each = (var.testzone || var.cluster_type == "development" || var.cluster_type == "playground") ? [1] : [] # TODO: move variable name to vars
-    content {
-      name    = "Lifecycle Storageaccount"
-      enabled = true
-      filters {
-        blob_types = ["blockBlob", "appendBlob"]
-      }
-      actions {
-        base_blob {
-          delete_after_days_since_modification_greater_than = 7
+        dynamic "base_blob" {
+          for_each = rule.value.delete_after_days_since_modification_greater_than == null && rule.value.tier_to_cool_after_days_since_modification_greater_than == null ? [] : [rule.value]
+          content {
+            delete_after_days_since_modification_greater_than       = base_blob.value.delete_after_days_since_modification_greater_than
+            tier_to_cool_after_days_since_modification_greater_than = base_blob.value.tier_to_cool_after_days_since_modification_greater_than
+          }
         }
       }
     }

--- a/terraform/subscriptions/modules/storageaccount/variables.tf
+++ b/terraform/subscriptions/modules/storageaccount/variables.tf
@@ -109,9 +109,29 @@ variable "virtual_network" {
 variable "vnet_resource_group" {
   type = string
 }
-variable "lifecyclepolicy" {
-  type    = bool
-  default = false
+variable "lifecycle_policy_rules" {
+  description = "Lifecycle management rules for the storage account. Non-default values must be provided by the zone configuration."
+  type = list(object({
+    name                                                    = optional(string, "Lifecycle Storageaccount")
+    enabled                                                 = optional(bool, true)
+    blob_types                                              = optional(list(string), ["blockBlob", "appendBlob"])
+    delete_after_days_since_creation                        = optional(number)
+    delete_after_days_since_modification_greater_than       = optional(number)
+    tier_to_cool_after_days_since_modification_greater_than = optional(number)
+  }))
+  default = []
+
+  validation {
+    condition = alltrue([
+      for rule in var.lifecycle_policy_rules :
+      length(rule.blob_types) > 0 && (
+        rule.delete_after_days_since_creation != null ||
+        rule.delete_after_days_since_modification_greater_than != null ||
+        rule.tier_to_cool_after_days_since_modification_greater_than != null
+      )
+    ])
+    error_message = "Each lifecycle policy rule must define at least one blob type and one lifecycle action."
+  }
 }
 
 variable "log_analytics_id" {
@@ -122,13 +142,4 @@ variable "log_analytics_id" {
 variable "public_network_access" {
   type    = bool
   default = false
-}
-
-variable "testzone" {
-  type    = bool
-  default = false
-}
-
-variable "cluster_type" {
-  type = string
 }

--- a/terraform/subscriptions/s940/c2/base-infrastructure/storageaccount.tf
+++ b/terraform/subscriptions/s940/c2/base-infrastructure/storageaccount.tf
@@ -21,10 +21,9 @@ module "storageaccount" {
   policyblobstorage_id     = module.backupvault.data.policyblobstorage.id
   subnet_id                = module.azurerm_virtual_network.azurerm_subnet_id
   vnet_resource_group      = module.config.vnet_resource_group
-  lifecyclepolicy          = each.value.lifecyclepolicy
+  lifecycle_policy_rules   = each.value.lifecycle_policy_rules
   log_analytics_id         = module.loganalytics.workspace_id
   subscription_shortname   = module.config.subscription_shortname
-  cluster_type             = module.config.cluster_type
   depends_on               = [module.backupvault]
 }
 

--- a/terraform/subscriptions/s940/c2/base-infrastructure/variables.tf
+++ b/terraform/subscriptions/s940/c2/base-infrastructure/variables.tf
@@ -12,20 +12,36 @@ variable "storageaccounts" {
     backup                   = optional(bool, false)
     principal_id             = optional(string)
     private_endpoint         = optional(bool, false)
-    lifecyclepolicy          = optional(bool, false)
+    lifecycle_policy_rules = optional(list(object({
+      name                                                    = optional(string, "Lifecycle Storageaccount")
+      enabled                                                 = optional(bool, true)
+      blob_types                                              = optional(list(string), ["blockBlob", "appendBlob"])
+      delete_after_days_since_creation                        = optional(number)
+      delete_after_days_since_modification_greater_than       = optional(number)
+      tier_to_cool_after_days_since_modification_greater_than = optional(number)
+    })), [])
   }))
   default = {
     log = {
       name                     = "log"
       account_replication_type = "ZRS"
       backup                   = true
+      lifecycle_policy_rules = [{
+        blob_types                                              = ["blockBlob"]
+        delete_after_days_since_creation                        = 60
+        delete_after_days_since_modification_greater_than       = 90
+        tier_to_cool_after_days_since_modification_greater_than = 30
+      }]
 
     },
     velero = {
       name                     = "velero"
       account_replication_type = "GRS"
       backup                   = true
-      lifecyclepolicy          = true
+      lifecycle_policy_rules = [{
+        delete_after_days_since_creation                  = 60
+        delete_after_days_since_modification_greater_than = 90
+      }]
     }
   }
 }

--- a/terraform/subscriptions/s940/c3/base-infrastructure/storageaccount.tf
+++ b/terraform/subscriptions/s940/c3/base-infrastructure/storageaccount.tf
@@ -21,10 +21,9 @@ module "storageaccount" {
   policyblobstorage_id     = module.backupvault.data.policyblobstorage.id
   subnet_id                = module.azurerm_virtual_network.azurerm_subnet_id
   vnet_resource_group      = module.config.vnet_resource_group
-  lifecyclepolicy          = each.value.lifecyclepolicy
+  lifecycle_policy_rules   = each.value.lifecycle_policy_rules
   log_analytics_id         = module.loganalytics.workspace_id
   subscription_shortname   = module.config.subscription_shortname
-  cluster_type             = module.config.cluster_type
   depends_on               = [module.backupvault]
 }
 

--- a/terraform/subscriptions/s940/c3/base-infrastructure/variables.tf
+++ b/terraform/subscriptions/s940/c3/base-infrastructure/variables.tf
@@ -10,20 +10,36 @@ variable "storageaccounts" {
     backup                   = optional(bool, false)
     principal_id             = optional(string)
     private_endpoint         = optional(bool, false)
-    lifecyclepolicy          = optional(bool, false)
+    lifecycle_policy_rules = optional(list(object({
+      name                                                    = optional(string, "Lifecycle Storageaccount")
+      enabled                                                 = optional(bool, true)
+      blob_types                                              = optional(list(string), ["blockBlob", "appendBlob"])
+      delete_after_days_since_creation                        = optional(number)
+      delete_after_days_since_modification_greater_than       = optional(number)
+      tier_to_cool_after_days_since_modification_greater_than = optional(number)
+    })), [])
   }))
   default = {
     log = {
       name                     = "log"
       account_replication_type = "ZRS"
       backup                   = true
+      lifecycle_policy_rules = [{
+        blob_types                                              = ["blockBlob"]
+        delete_after_days_since_creation                        = 60
+        delete_after_days_since_modification_greater_than       = 90
+        tier_to_cool_after_days_since_modification_greater_than = 30
+      }]
 
     },
     velero = {
       name                     = "velero"
       account_replication_type = "GRS"
       backup                   = true
-      lifecyclepolicy          = true
+      lifecycle_policy_rules = [{
+        delete_after_days_since_creation                  = 60
+        delete_after_days_since_modification_greater_than = 90
+      }]
     }
   }
 }

--- a/terraform/subscriptions/s940/extmon/base-infrastructure/storageaccount.tf
+++ b/terraform/subscriptions/s940/extmon/base-infrastructure/storageaccount.tf
@@ -25,10 +25,9 @@ module "storageaccount" {
   policyblobstorage_id     = "${data.azurerm_data_protection_backup_vault.this.id}/backupPolicies/Backuppolicy-blob"
   subnet_id                = module.azurerm_virtual_network.azurerm_subnet_id
   vnet_resource_group      = module.config.vnet_resource_group
-  lifecyclepolicy          = each.value.lifecyclepolicy
+  lifecycle_policy_rules   = each.value.lifecycle_policy_rules
   log_analytics_id         = module.loganalytics.workspace_id
   subscription_shortname   = module.config.subscription_shortname
-  cluster_type             = module.config.cluster_type
 }
 
 output "velero_storage_account" {

--- a/terraform/subscriptions/s940/extmon/base-infrastructure/variables.tf
+++ b/terraform/subscriptions/s940/extmon/base-infrastructure/variables.tf
@@ -12,15 +12,31 @@ variable "storageaccounts" {
     backup                   = optional(bool, false)
     principal_id             = optional(string)
     private_endpoint         = optional(bool, false)
-    lifecyclepolicy          = optional(bool, false)
+    lifecycle_policy_rules = optional(list(object({
+      name                                                    = optional(string, "Lifecycle Storageaccount")
+      enabled                                                 = optional(bool, true)
+      blob_types                                              = optional(list(string), ["blockBlob", "appendBlob"])
+      delete_after_days_since_creation                        = optional(number)
+      delete_after_days_since_modification_greater_than       = optional(number)
+      tier_to_cool_after_days_since_modification_greater_than = optional(number)
+    })), [])
   }))
   default = {
     log = {
       name = "log"
+      lifecycle_policy_rules = [{
+        blob_types                                              = ["blockBlob"]
+        delete_after_days_since_creation                        = 60
+        delete_after_days_since_modification_greater_than       = 90
+        tier_to_cool_after_days_since_modification_greater_than = 30
+      }]
     },
     velero = {
-      name            = "velero"
-      lifecyclepolicy = true
+      name = "velero"
+      lifecycle_policy_rules = [{
+        delete_after_days_since_creation                  = 60
+        delete_after_days_since_modification_greater_than = 90
+      }]
     }
   }
 }

--- a/terraform/subscriptions/s940/prod/base-infrastructure/storageaccount.tf
+++ b/terraform/subscriptions/s940/prod/base-infrastructure/storageaccount.tf
@@ -25,10 +25,9 @@ module "storageaccount" {
   policyblobstorage_id     = "${data.azurerm_data_protection_backup_vault.this.id}/backupPolicies/Backuppolicy-blob"
   subnet_id                = module.azurerm_virtual_network.azurerm_subnet_id
   vnet_resource_group      = module.config.vnet_resource_group
-  lifecyclepolicy          = each.value.lifecyclepolicy
+  lifecycle_policy_rules   = each.value.lifecycle_policy_rules
   log_analytics_id         = module.loganalytics.workspace_id
   subscription_shortname   = module.config.subscription_shortname
-  cluster_type             = module.config.cluster_type
 }
 
 output "velero_storage_account" {

--- a/terraform/subscriptions/s940/prod/base-infrastructure/variables.tf
+++ b/terraform/subscriptions/s940/prod/base-infrastructure/variables.tf
@@ -11,20 +11,36 @@ variable "storageaccounts" {
     backup                   = optional(bool, false)
     principal_id             = optional(string)
     private_endpoint         = optional(bool, false)
-    lifecyclepolicy          = optional(bool, false)
+    lifecycle_policy_rules = optional(list(object({
+      name                                                    = optional(string, "Lifecycle Storageaccount")
+      enabled                                                 = optional(bool, true)
+      blob_types                                              = optional(list(string), ["blockBlob", "appendBlob"])
+      delete_after_days_since_creation                        = optional(number)
+      delete_after_days_since_modification_greater_than       = optional(number)
+      tier_to_cool_after_days_since_modification_greater_than = optional(number)
+    })), [])
   }))
   default = {
     log = {
       name                     = "log"
       account_replication_type = "ZRS"
       backup                   = true
+      lifecycle_policy_rules = [{
+        blob_types                                              = ["blockBlob"]
+        delete_after_days_since_creation                        = 60
+        delete_after_days_since_modification_greater_than       = 90
+        tier_to_cool_after_days_since_modification_greater_than = 30
+      }]
 
     },
     velero = {
       name                     = "velero"
       account_replication_type = "GRS"
       backup                   = true
-      lifecyclepolicy          = true
+      lifecycle_policy_rules = [{
+        delete_after_days_since_creation                  = 60
+        delete_after_days_since_modification_greater_than = 90
+      }]
     }
   }
 }

--- a/terraform/subscriptions/s941/dev/base-infrastructure/storageaccount.tf
+++ b/terraform/subscriptions/s941/dev/base-infrastructure/storageaccount.tf
@@ -18,10 +18,9 @@ module "storageaccount" {
   backup                   = each.value.backup
   subnet_id                = module.azurerm_virtual_network.azurerm_subnet_id
   vnet_resource_group      = module.azurerm_virtual_network.data.vnet_subnet.resource_group_name
-  lifecyclepolicy          = each.value.lifecyclepolicy
+  lifecycle_policy_rules   = each.value.lifecycle_policy_rules
   log_analytics_id         = module.loganalytics.workspace_id
   subscription_shortname   = module.config.subscription_shortname
-  cluster_type             = module.config.cluster_type
 }
 
 output "velero_storage_account" {

--- a/terraform/subscriptions/s941/dev/base-infrastructure/variables.tf
+++ b/terraform/subscriptions/s941/dev/base-infrastructure/variables.tf
@@ -11,15 +11,27 @@ variable "storageaccounts" {
     backup                   = optional(bool, false)
     principal_id             = optional(string)
     private_endpoint         = optional(bool, false)
-    lifecyclepolicy          = optional(bool, false)
+    lifecycle_policy_rules = optional(list(object({
+      name                                                    = optional(string, "Lifecycle Storageaccount")
+      enabled                                                 = optional(bool, true)
+      blob_types                                              = optional(list(string), ["blockBlob", "appendBlob"])
+      delete_after_days_since_creation                        = optional(number)
+      delete_after_days_since_modification_greater_than       = optional(number)
+      tier_to_cool_after_days_since_modification_greater_than = optional(number)
+    })), [])
   }))
   default = {
     log = {
       name = "log"
+      lifecycle_policy_rules = [{
+        delete_after_days_since_modification_greater_than = 7
+      }]
     },
     velero = {
-      name            = "velero"
-      lifecyclepolicy = true
+      name = "velero"
+      lifecycle_policy_rules = [{
+        delete_after_days_since_modification_greater_than = 7
+      }]
     }
   }
 }

--- a/terraform/subscriptions/s941/playground/base-infrastructure/storageaccount.tf
+++ b/terraform/subscriptions/s941/playground/base-infrastructure/storageaccount.tf
@@ -18,10 +18,9 @@ module "storageaccount" {
   backup                   = each.value.backup
   subnet_id                = module.azurerm_virtual_network.azurerm_subnet_id
   vnet_resource_group      = module.config.vnet_resource_group
-  lifecyclepolicy          = each.value.lifecyclepolicy
+  lifecycle_policy_rules   = each.value.lifecycle_policy_rules
   log_analytics_id         = module.loganalytics.workspace_id
   subscription_shortname   = module.config.subscription_shortname
-  cluster_type             = module.config.cluster_type
 }
 
 output "velero_storage_account" {

--- a/terraform/subscriptions/s941/playground/base-infrastructure/variables.tf
+++ b/terraform/subscriptions/s941/playground/base-infrastructure/variables.tf
@@ -12,15 +12,27 @@ variable "storageaccounts" {
     backup                   = optional(bool, false)
     principal_id             = optional(string)
     private_endpoint         = optional(bool, false)
-    lifecyclepolicy          = optional(bool, false)
+    lifecycle_policy_rules = optional(list(object({
+      name                                                    = optional(string, "Lifecycle Storageaccount")
+      enabled                                                 = optional(bool, true)
+      blob_types                                              = optional(list(string), ["blockBlob", "appendBlob"])
+      delete_after_days_since_creation                        = optional(number)
+      delete_after_days_since_modification_greater_than       = optional(number)
+      tier_to_cool_after_days_since_modification_greater_than = optional(number)
+    })), [])
   }))
   default = {
     log = {
       name = "log"
+      lifecycle_policy_rules = [{
+        delete_after_days_since_modification_greater_than = 7
+      }]
     },
     velero = {
-      name            = "velero"
-      lifecyclepolicy = true
+      name = "velero"
+      lifecycle_policy_rules = [{
+        delete_after_days_since_modification_greater_than = 7
+      }]
     }
   }
 }


### PR DESCRIPTION
### Summary
This PR makes storage account lifecycle management fully declarative.

Refactored the storage account module to render lifecycle policy rules from zone input instead of deriving behavior from implicit module logic.
Introduced a structured lifecycle policy rules input with module-side defaults only for optional fields.
Added validation to ensure each lifecycle rule has at least one blob type and at least one lifecycle action.
Updated all affected zone configurations to define lifecycle policy rules explicitly in their storage account settings.
Wired the new lifecycle rules through all storage account module callers in the touched subscriptions/environments.
### Why
This aligns module behavior with the desired pattern: module defaults are allowed, but all non-default lifecycle behavior is defined explicitly at zone level.
### 
Verification
Ran terraform fmt on all updated module and zone files.