### PR TITLE
feat: Update dns_wildcard to use istio for playground cluster

### DIFF
--- a/terraform/subscriptions/s941/playground/config.yaml
+++ b/terraform/subscriptions/s941/playground/config.yaml
@@ -47,5 +47,5 @@ clusters:
     networkset: "networkset1"
     network_policy: "cilium"
     dns_prefix: "playground-clusters-playgro-16ede4"
-    dns_wildcard: nginx # Options: "nginx" or "istio"
+    dns_wildcard: istio # Options: "nginx" or "istio"
     activecluster: true


### PR DESCRIPTION
Use Istio load balancer IP for all wildcard DNS entries