### PR TITLE
Add Kusto private link to private DNS zones output

### DIFF
--- a/terraform/subscriptions/modules/config/main.tf
+++ b/terraform/subscriptions/modules/config/main.tf
@@ -95,7 +95,8 @@ output "private_dns_zones_names" {
     "privatelink.table.core.windows.net",
     "privatelink.table.cosmos.azure.com",
     "privatelink.vaultcore.azure.net",
-    "privatelink.web.core.windows.net"
+    "privatelink.web.core.windows.net",
+    "privatelink.kusto.windows.net"
   ]
 }
 


### PR DESCRIPTION
Include the Kusto private link in the output for private DNS zones.