### PR TITLE
Add Kusto private link to private DNS zones output

### DIFF
--- a/terraform/subscriptions/modules/config/main.tf
+++ b/terraform/subscriptions/modules/config/main.tf
@@ -95,7 +95,8 @@ output "private_dns_zones_names" {
     "privatelink.table.core.windows.net",
     "privatelink.table.cosmos.azure.com",
     "privatelink.vaultcore.azure.net",
-    "privatelink.web.core.windows.net"
+    "privatelink.web.core.windows.net",
+    "privatelink.kusto.windows.net"
   ]
 }
 

--- a/terraform/subscriptions/modules/config/main.tf
+++ b/terraform/subscriptions/modules/config/main.tf
@@ -96,7 +96,9 @@ output "private_dns_zones_names" {
     "privatelink.table.cosmos.azure.com",
     "privatelink.vaultcore.azure.net",
     "privatelink.web.core.windows.net",
-    "privatelink.kusto.windows.net"
+    "privatelink.northeurope.kusto.windows.net",
+    "privatelink.westeurope.kusto.windows.net",
+    "privatelink.swedencentral.kusto.windows.net"
   ]
 }
 


### PR DESCRIPTION
Enhance the output of private DNS zones to include Kusto private links for multiple regions. This update adds custom private DNS zones for Kusto services.