### PR TITLE
Enhance cost analysis configuration across modules

### DIFF
--- a/terraform/subscriptions/modules/acr/main.tf
+++ b/terraform/subscriptions/modules/acr/main.tf
@@ -123,16 +123,16 @@ resource "azurerm_container_registry" "env" {
 }
 
 resource "azurerm_container_registry_agent_pool" "user_image_pool" {
-  name                  = "${var.acr_prefix_env}-zone-pool"
-  resource_group_name   = var.resource_group_name
-  location              = var.location
+  name                    = "${var.acr_prefix_env}-zone-pool"
+  resource_group_name     = var.resource_group_name
+  location                = var.location
   container_registry_name = var.acr_user_image_name
-  
+
   # Set the number of agent instances (1-1000)
-  instance_count        = var.user_registry_pool_count
-  
+  instance_count = var.user_registry_pool_count
+
   # Select the VM SKU
-  tier                  = "S1" # Options: S1, S2, S3, I6
+  tier = "S1" # Options: S1, S2, S3, I6
   tags = {
     IaC = "terraform"
   }

--- a/terraform/subscriptions/modules/aks/dns_config/variables.tf
+++ b/terraform/subscriptions/modules/aks/dns_config/variables.tf
@@ -1,9 +1,9 @@
 variable "clusters" {
   description = "Map of cluster configurations with IP addresses"
   type = map(object({
-    cluster_name      = string
-    active_cluster    = bool
-    istio_ip          = string
+    cluster_name   = string
+    active_cluster = bool
+    istio_ip       = string
   }))
 }
 

--- a/terraform/subscriptions/s940/c2/config.yaml
+++ b/terraform/subscriptions/s940/c2/config.yaml
@@ -77,3 +77,4 @@ clusters:
     ContainerInsights_time: "1m"
     cluster_to_hub_peering: "c2-11-to-vnet-hub"
     hub_to_cluster_peering: "vnet-hub-to-c2-11"
+    cost_analysis: true

--- a/terraform/subscriptions/s940/c2/post-clusters/dns.tf
+++ b/terraform/subscriptions/s940/c2/post-clusters/dns.tf
@@ -9,9 +9,9 @@ locals {
   # Prepare cluster data for DNS module
   clusters_for_dns = {
     for cluster_name, cluster_config in module.config.cluster : cluster_name => {
-      cluster_name      = cluster_name
-      active_cluster    = lookup(cluster_config, "activecluster", false)
-      istio_ip          = data.azurerm_public_ip.gateway_pip[cluster_config.networkset].ip_address
+      cluster_name   = cluster_name
+      active_cluster = lookup(cluster_config, "activecluster", false)
+      istio_ip       = data.azurerm_public_ip.gateway_pip[cluster_config.networkset].ip_address
     }
   }
 }

--- a/terraform/subscriptions/s940/c2/pre-clusters/aks.tf
+++ b/terraform/subscriptions/s940/c2/pre-clusters/aks.tf
@@ -75,6 +75,7 @@ module "aks" {
   private_dns_zone_link_name        = "${each.key}-link"
   monitor_data_collection_rule_name = "MSCI-${module.config.location}-${each.key}"
   hostencryption                    = lookup(module.config.cluster[each.key], "hostencryption", false)
+  cost_analysis                     = lookup(module.config.cluster[each.key], "cost_analysis", false)
 }
 
 locals {

--- a/terraform/subscriptions/s940/c3/config.yaml
+++ b/terraform/subscriptions/s940/c3/config.yaml
@@ -87,3 +87,4 @@ clusters:
     networkset: "networkset1"
     network_policy: "cilium"
     activecluster: true
+    cost_analysis: true

--- a/terraform/subscriptions/s940/c3/post-clusters/dns.tf
+++ b/terraform/subscriptions/s940/c3/post-clusters/dns.tf
@@ -9,9 +9,9 @@ locals {
   # Prepare cluster data for DNS module
   clusters_for_dns = {
     for cluster_name, cluster_config in module.config.cluster : cluster_name => {
-      cluster_name      = cluster_name
-      active_cluster    = lookup(cluster_config, "activecluster", false)
-      istio_ip          = data.azurerm_public_ip.gateway_pip[cluster_config.networkset].ip_address
+      cluster_name   = cluster_name
+      active_cluster = lookup(cluster_config, "activecluster", false)
+      istio_ip       = data.azurerm_public_ip.gateway_pip[cluster_config.networkset].ip_address
     }
   }
 }

--- a/terraform/subscriptions/s940/c3/pre-clusters/aks.tf
+++ b/terraform/subscriptions/s940/c3/pre-clusters/aks.tf
@@ -75,6 +75,7 @@ module "aks" {
   private_dns_zone_link_name        = "${each.key}-link"
   monitor_data_collection_rule_name = "MSCI-${module.config.location}-${each.key}"
   hostencryption                    = lookup(module.config.cluster[each.key], "hostencryption", false)
+  cost_analysis                     = lookup(module.config.cluster[each.key], "cost_analysis", false)
 
 }
 

--- a/terraform/subscriptions/s940/extmon/post-clusters/dns.tf
+++ b/terraform/subscriptions/s940/extmon/post-clusters/dns.tf
@@ -9,9 +9,9 @@ locals {
   # Prepare cluster data for DNS module
   clusters_for_dns = {
     for cluster_name, cluster_config in module.config.cluster : cluster_name => {
-      cluster_name      = cluster_name
-      active_cluster    = lookup(cluster_config, "activecluster", false)
-      istio_ip          = data.azurerm_public_ip.gateway_pip[cluster_config.networkset].ip_address
+      cluster_name   = cluster_name
+      active_cluster = lookup(cluster_config, "activecluster", false)
+      istio_ip       = data.azurerm_public_ip.gateway_pip[cluster_config.networkset].ip_address
     }
   }
 }

--- a/terraform/subscriptions/s940/prod/base-infrastructure/virtualnetwork.tf
+++ b/terraform/subscriptions/s940/prod/base-infrastructure/virtualnetwork.tf
@@ -64,7 +64,7 @@ module "azurerm_public_ip_prefix_egress_platform" {
 module "azurerm_public_ip_prefix_egress_002" {
   source               = "../../../modules/network_publicipprefix"
   location             = module.config.location
-  resource_group_name  = "clusters-c1" #TODO Will be removed when old cluster are decommissioned
+  resource_group_name  = "clusters-c1"                                            #TODO Will be removed when old cluster are decommissioned
   publicipprefixname   = "ippre-radix-aks-platform-${module.config.location}-002" #TODO
   pipprefix            = "radix-aks"
   pippostfix           = module.config.location
@@ -77,7 +77,7 @@ module "azurerm_public_ip_prefix_egress_002" {
 module "azurerm_public_ip_prefix_egress_003" {
   source               = "../../../modules/network_publicipprefix"
   location             = module.config.location
-  resource_group_name  = "clusters-c1" #TODO Will be removed when old cluster are decommissioned
+  resource_group_name  = "clusters-c1"                                            #TODO Will be removed when old cluster are decommissioned
   publicipprefixname   = "ippre-radix-aks-platform-${module.config.location}-003" #TODO
   pipprefix            = "radix-aks"
   pippostfix           = module.config.location

--- a/terraform/subscriptions/s940/prod/post-clusters/dns.tf
+++ b/terraform/subscriptions/s940/prod/post-clusters/dns.tf
@@ -15,9 +15,9 @@ locals {
   # Prepare cluster data for DNS module
   clusters_for_dns = {
     for cluster_name, cluster_config in module.config.cluster : cluster_name => {
-      cluster_name      = cluster_name
-      active_cluster    = lookup(cluster_config, "activecluster", false)
-      istio_ip          = data.azurerm_public_ip.gateway_pip[cluster_config.networkset].ip_address
+      cluster_name   = cluster_name
+      active_cluster = lookup(cluster_config, "activecluster", false)
+      istio_ip       = data.azurerm_public_ip.gateway_pip[cluster_config.networkset].ip_address
     }
   }
 }

--- a/terraform/subscriptions/s940/prod/post-clusters/web-console.tf
+++ b/terraform/subscriptions/s940/prod/post-clusters/web-console.tf
@@ -1,6 +1,6 @@
 locals {
   web-uris = distinct(flatten(
-    [for k, v in local.oidc_issuer_urls: [
+    [for k, v in local.oidc_issuer_urls : [
       "http://localhost:8000/oauth2/callback",
 
       "https://console.radix.equinor.com/oauth2/callback",

--- a/terraform/subscriptions/s941/dev/post-clusters/dns.tf
+++ b/terraform/subscriptions/s941/dev/post-clusters/dns.tf
@@ -9,9 +9,9 @@ locals {
   # Prepare cluster data for DNS module
   clusters_for_dns = {
     for cluster_name, cluster_config in module.config.cluster : cluster_name => {
-      cluster_name      = cluster_name
-      active_cluster    = lookup(cluster_config, "activecluster", false)
-      istio_ip          = data.azurerm_public_ip.gateway_pip[cluster_config.networkset].ip_address
+      cluster_name   = cluster_name
+      active_cluster = lookup(cluster_config, "activecluster", false)
+      istio_ip       = data.azurerm_public_ip.gateway_pip[cluster_config.networkset].ip_address
     }
   }
 }

--- a/terraform/subscriptions/s941/playground/post-clusters/dns.tf
+++ b/terraform/subscriptions/s941/playground/post-clusters/dns.tf
@@ -9,9 +9,9 @@ locals {
   # Prepare cluster data for DNS module
   clusters_for_dns = {
     for cluster_name, cluster_config in module.config.cluster : cluster_name => {
-      cluster_name      = cluster_name
-      active_cluster    = lookup(cluster_config, "activecluster", false)
-      istio_ip          = data.azurerm_public_ip.gateway_pip[cluster_config.networkset].ip_address
+      cluster_name   = cluster_name
+      active_cluster = lookup(cluster_config, "activecluster", false)
+      istio_ip       = data.azurerm_public_ip.gateway_pip[cluster_config.networkset].ip_address
     }
   }
 }


### PR DESCRIPTION
This pull request introduces support for enabling cost analysis on AKS clusters by adding a new `cost_analysis` configuration option. The main changes involve updating cluster configuration files to include the `cost_analysis` flag and ensuring this value is passed through to the AKS module in the Terraform code.

Configuration updates:

* Added `cost_analysis: true` to the `clusters` entries in `terraform/subscriptions/s940/c2/config.yaml` and `terraform/subscriptions/s940/c3/config.yaml` to enable cost analysis for the respective clusters. [[1]](diffhunk://#diff-a9e8334e91cd53e7986fa0bc661c9d79837a44aaecfccbb9a5eb8c458ec6daebR80) [[2]](diffhunk://#diff-e4e860dad79eadc4ffc76c9c37cd5aa0783a2482851e49218786d31c2e3e0119R90)

Terraform module integration:

* Updated the AKS module instantiations in `terraform/subscriptions/s940/c2/pre-clusters/aks.tf` and `terraform/subscriptions/s940/c3/pre-clusters/aks.tf` to pass the `cost_analysis` value from cluster configuration, defaulting to `false` if not set. [[1]](diffhunk://#diff-21509bc1bfe6eae53f7d26b2b58112265e24f994bd233978d7180efe32f1dd24R78) [[2]](diffhunk://#diff-cb7a7ef595ac9f90102b87c86b5e2bdb7ce6e904e733fbd6169de4a04190e748R78)