### PR TITLE
chore: update AKS version to 1.34.6 in playground configuration

### DIFF
--- a/terraform/subscriptions/s941/playground/config.yaml
+++ b/terraform/subscriptions/s941/playground/config.yaml
@@ -41,7 +41,7 @@ networksets:
       - "/subscriptions/16ede44b-1f74-40a5-b428-46cca9a5741b/resourceGroups/clusters-playground/providers/Microsoft.Network/publicIPAddresses/pip-radix-aks-playground-northeurope-008"
 clusters:
   playground-29:
-    aksversion: "1.33.6"
+    aksversion: "1.34.6"
     networkset: "networkset1"
     network_policy: "cilium"
     dns_prefix: "playground-clusters-playgro-16ede4"


### PR DESCRIPTION
The version in terraform did not match the actual AKS version for playground