### PR TITLE
Add new private DNS zones for Azure Machine Learning

### DIFF
--- a/terraform/subscriptions/modules/config/main.tf
+++ b/terraform/subscriptions/modules/config/main.tf
@@ -99,7 +99,9 @@ output "private_dns_zones_names" {
     "privatelink.northeurope.kusto.windows.net",
     "privatelink.westeurope.kusto.windows.net",
     "privatelink.swedencentral.kusto.windows.net",
-    "privatelink.redis.azure.net"
+    "privatelink.redis.azure.net",
+    "privatelink.notebooks.azure.net",
+    "privatelink.api.azureml.ms"
   ]
 }
 

--- a/terraform/subscriptions/s941/dev/config.yaml
+++ b/terraform/subscriptions/s941/dev/config.yaml
@@ -16,9 +16,8 @@ zoneconfig:
   RADIX_API_REQUIRE_APP_AD_GROUPS: "true"
   APP_REGISTRATION_NETWORKPOLICY_CANARY: "radix-ar-networkpolicy-canary"
 
-aksconfig: 
+aksconfig:
   dataCollectionSettings: "5m"
-
 
 backend:
   resource_group_name: "s941-tfstate"
@@ -48,7 +47,7 @@ clusters:
     network_policy: "cilium"
     hostencryption: true
     activecluster: true
-  weekly-20:
+  weekly-22:
     aksversion: "1.35.1"
     networkset: "networkset2"
     network_policy: "cilium"


### PR DESCRIPTION
Introduce new private DNS zones for Azure Machine Learning and update the cluster configuration accordingly. This enhances the networking capabilities for the Azure environment.