### PR TITLE
Add configuration for external secrets operator with federated credentials

### DIFF
--- a/terraform/subscriptions/s940/extmon/pre-clusters/external-secrets-operator.tf
+++ b/terraform/subscriptions/s940/extmon/pre-clusters/external-secrets-operator.tf
@@ -1,0 +1,40 @@
+data "azurerm_user_assigned_identity" "this" {
+  resource_group_name = module.config.common_resource_group
+  name                = "radix-id-external-secrets-operator-${module.config.environment}"
+}
+
+locals {
+  namespaces = ["default", "flux-system", "radix-cicd-canary"]
+  eso_namespaced_credentials = merge([
+    for cluster_key, issuer_url in module.clusters.oidc_issuer_url : {
+      for namespace in local.namespaces :
+      "${cluster_key}-${namespace}" => {
+        cluster_key = cluster_key
+        issuer_url  = issuer_url
+        namespace   = namespace
+      }
+    }
+  ]...)
+}
+
+module "eso" {
+  source              = "../../../modules/federated-credentials"
+  for_each            = module.clusters.oidc_issuer_url
+  name                = "operator-wi-${each.key}"
+  issuer              = each.value
+  subject             = "system:serviceaccount:external-secrets:workload-identity-sa"
+  parent_id           = data.azurerm_user_assigned_identity.this.id
+  resource_group_name = data.azurerm_user_assigned_identity.this.resource_group_name
+  depends_on          = [module.aks]
+}
+
+module "eso_namespaced" {
+  source              = "../../../modules/federated-credentials"
+  for_each            = local.eso_namespaced_credentials
+  name                = "operator-wi-${each.value.cluster_key}-${each.value.namespace}"
+  issuer              = each.value.issuer_url
+  subject             = "system:serviceaccount:${each.value.namespace}:workload-identity-sa"
+  parent_id           = data.azurerm_user_assigned_identity.this.id
+  resource_group_name = data.azurerm_user_assigned_identity.this.resource_group_name
+  depends_on          = [module.aks]
+}


### PR DESCRIPTION
This pull request introduces new Terraform configuration to support federated credentials for the external-secrets-operator across multiple clusters and namespaces. The main changes focus on automating the creation of federated credentials for both cluster-wide and namespace-specific service accounts, improving scalability and maintainability.

**Federated credential management:**

* Added a data source for `azurerm_user_assigned_identity` to retrieve the managed identity used by the external-secrets-operator, parameterized by environment.
* Defined a local variable `eso_namespaced_credentials` to dynamically generate federated credential definitions for a set of namespaces across all clusters.

**Module instantiations:**

* Added a `module "eso"` block to create federated credentials for the external-secrets-operator's service account at the cluster level for each cluster.
* Added a `module "eso_namespaced"` block to create federated credentials for the external-secrets-operator's service account in each specified namespace for each cluster.…entials