### PR TITLE
feat: add configuration for c2-24 cluster and update nodepool/systemp…

### DIFF
--- a/terraform/subscriptions/s940/c2/config.yaml
+++ b/terraform/subscriptions/s940/c2/config.yaml
@@ -77,3 +77,12 @@ clusters:
     ContainerInsights_time: "1m"
     cluster_to_hub_peering: "c2-11-to-vnet-hub"
     hub_to_cluster_peering: "vnet-hub-to-c2-11"
+  c2-24:
+    aksversion: "1.35.5"
+    networkset: "networkset2"
+    network_policy: "cilium"
+    activecluster: false
+    ddos_protection: true
+    ContainerInsights_time: "1m"
+    systempool: "systempool_v1"
+    nodepools: "nodepools_v1"

--- a/terraform/subscriptions/s940/c2/pre-clusters/aks.tf
+++ b/terraform/subscriptions/s940/c2/pre-clusters/aks.tf
@@ -33,6 +33,18 @@ data "azurerm_virtual_network" "hub" {
   resource_group_name = module.config.vnet_resource_group
 }
 
+locals {
+  systempool_variants = {
+    systempool    = var.systempool
+    systempool_v1 = var.systempool_v1
+  }
+
+  nodepools_variants = {
+    nodepools    = var.nodepools
+    nodepools_v1 = var.nodepools_v1
+  }
+}
+
 module "aks" {
   source                            = "../../../modules/aks"
   for_each                          = module.config.cluster
@@ -46,8 +58,8 @@ module "aks" {
   enviroment                        = module.config.environment
   aks_version                       = each.value.aksversion
   authorized_ip_ranges              = split(",", data.azurerm_app_configuration_key.ip_range.value)
-  nodepools                         = var.nodepools
-  systempool                        = var.systempool
+  nodepools                         = lookup(local.nodepools_variants, lookup(each.value, "nodepools", "nodepools"), var.nodepools)
+  systempool                        = lookup(local.systempool_variants, lookup(each.value, "systempool", "systempool"), var.systempool)
   identity_aks                      = data.azurerm_user_assigned_identity.aks.id
   identity_kublet_client            = data.azurerm_user_assigned_identity.akskubelet.client_id
   identity_kublet_object            = data.azurerm_user_assigned_identity.akskubelet.principal_id

--- a/terraform/subscriptions/s940/c2/pre-clusters/variables.tf
+++ b/terraform/subscriptions/s940/c2/pre-clusters/variables.tf
@@ -16,6 +16,24 @@ variable "systempool" {
   }
 }
 
+variable "systempool_v1" {
+  type = object({
+    vm_size   = string
+    tags      = optional(map(string))
+    min_nodes = number
+    max_nodes = number
+  })
+
+  default = {
+    vm_size = "Standard_E16as_v7"
+    tags = {
+      "nodepool" = "systempool"
+    }
+    min_nodes = 3
+    max_nodes = 4
+  }
+}
+
 variable "nodepools" {
   type = map(object({
     vm_size         = string
@@ -92,6 +110,98 @@ variable "nodepools" {
       vm_size   = "Standard_E16as_v7"
       min_count = 2
       max_count = 16
+    }
+  }
+}
+
+variable "nodepools_v1" {
+  type = map(object({
+    vm_size         = string
+    min_count       = number
+    max_count       = number
+    node_count      = optional(number, 1)
+    node_labels     = optional(map(string))
+    node_taints     = optional(list(string), [])
+    os_disk_type    = optional(string, "Managed")
+    nodepool_os_sku = optional(string, "Ubuntu")
+  }))
+  default = {
+    memory2v1 = {
+      vm_size    = "Standard_M96s_2_v3"
+      min_count  = 0
+      max_count  = 2
+      node_count = 0
+      node_labels = {
+        "radix-nodetype" = "memory-optimized-2-v1"
+      }
+      node_taints = ["radix-nodetype=memory-optimized-2-v1:NoSchedule"]
+    }
+    nvidia1v1 = {
+      vm_size    = "Standard_NC40ads_H100_v5"
+      min_count  = 0
+      max_count  = 1
+      node_count = 0
+      node_labels = {
+        "radix-nodetype" = "gpu-nvidia-1-v1"
+      }
+      node_taints  = ["radix-nodetype=gpu-nvidia-1-v1:NoSchedule"]
+      os_disk_type = "Managed" # Standard_NC40ads_H100_v5 fail to boot if disk type is Ephemeral
+    }
+    nc6sv3 = {
+      vm_size    = "Standard_NC40ads_H100_v5"
+      min_count  = 0
+      max_count  = 1
+      node_count = 0
+      node_labels = {
+        "gpu"                  = "nvidia-v100"
+        "gpu-count"            = "1"
+        "radix-node-gpu"       = "nvidia-v100"
+        "radix-node-gpu-count" = "1"
+        "sku"                  = "gpu"
+      }
+      node_taints  = ["radix-node-gpu-count=1:NoSchedule"]
+      os_disk_type = "Ephemeral"
+    }
+    armpipepool = {
+      vm_size   = "Standard_E16ps_v6"
+      min_count = 1
+      max_count = 2
+      node_labels = {
+        "nodepooltasks" = "jobs"
+      }
+      node_taints = ["nodepooltasks=jobs:NoSchedule"]
+    }
+    armuserpool = {
+      vm_size   = "Standard_E16ps_v6"
+      min_count = 1
+      max_count = 4
+
+    }
+    x86pipepool = {
+      vm_size   = "Standard_E16as_v7"
+      min_count = 1
+      max_count = 2
+      node_labels = {
+        "nodepooltasks" = "jobs"
+      }
+      node_taints = ["nodepooltasks=jobs:NoSchedule"]
+
+    }
+    x86userpool = {
+      vm_size   = "Standard_E16as_v7"
+      min_count = 1
+      max_count = 2
+
+    }
+    monitorpool = {
+      vm_size   = "Standard_E20ps_v5"
+      min_count = 1
+      max_count = 2
+      node_labels = {
+        "nodepooltasks" = "monitor"
+      }
+      node_taints = ["nodetasks=monitor:NoSchedule"]
+
     }
   }
 }


### PR DESCRIPTION
This pull request introduces support for new variants of system and node pools in the AKS cluster configuration, enabling more flexible and granular cluster definitions. It adds new variables and logic to select between different pool variants on a per-cluster basis, and demonstrates this by adding a new cluster (`c2-24`) using the new variants.

**Support for nodepool and systempool variants:**

* Added new variables `systempool_v1` and `nodepools_v1` in `variables.tf`, each with their own default configurations to allow for alternative pool definitions. [[1]](diffhunk://#diff-27c4b272b7ab68e0fab1f482cef80766d9a0aa424fbd21c8719df9abdb0d44b0R19-R36) [[2]](diffhunk://#diff-27c4b272b7ab68e0fab1f482cef80766d9a0aa424fbd21c8719df9abdb0d44b0R116-R207)
* Created local maps (`systempool_variants` and `nodepools_variants`) in `aks.tf` to reference the correct pool variant based on cluster configuration.
* Updated the `aks` module instantiation in `aks.tf` to dynamically select the appropriate pool variant for each cluster using the new local maps and cluster-specific configuration.

**Cluster configuration enhancements:**

* Added a new cluster definition (`c2-24`) in `config.yaml` that utilizes the new `systempool_v1` and `nodepools_v1` variants, as well as other configuration options like network policy and DDoS protection.…ool variables