### PR TITLE
feat: add scaling diagnostics for cluster autoscaler and karpenter ev…

### DIFF
--- a/terraform/subscriptions/modules/aks/monitor.tf
+++ b/terraform/subscriptions/modules/aks/monitor.tf
@@ -17,6 +17,22 @@
 #   }
 # }
 
+resource "azurerm_monitor_diagnostic_setting" "scalediagnostic" {
+  count = var.scalediagnostic_enabled ? 1 : 0
+  name               = "Radix-Scale-Diagnostics"
+  target_resource_id = azurerm_kubernetes_cluster.this.id
+  log_analytics_workspace_id = var.defender_workspace_id
+  log_analytics_destination_type = "Dedicated"
+
+  enabled_log {
+    category = "cluster-autoscaler"
+  }
+
+  enabled_log {
+    category = "karpenter-events"
+  }
+}
+
 resource "azurerm_monitor_data_collection_rule" "this" {
   name                = var.monitor_data_collection_rule_name
   resource_group_name = var.resource_group

--- a/terraform/subscriptions/modules/aks/variables.tf
+++ b/terraform/subscriptions/modules/aks/variables.tf
@@ -246,3 +246,9 @@ variable "tags" {
   type        = map(string)
   default     = {}
 }
+
+variable "scalediagnostic_enabled" {
+  description = "Enable diagnostics for cluster autoscaler and karpenter events."
+  type        = bool
+  default     = false
+}

--- a/terraform/subscriptions/s940/c2/config.yaml
+++ b/terraform/subscriptions/s940/c2/config.yaml
@@ -77,6 +77,7 @@ clusters:
     ContainerInsights_time: "1m"
     cluster_to_hub_peering: "c2-11-to-vnet-hub"
     hub_to_cluster_peering: "vnet-hub-to-c2-11"
+    scalediagnostic_enabled: true
   c2-24:
     aksversion: "1.35.5"
     networkset: "networkset2"
@@ -86,3 +87,4 @@ clusters:
     ContainerInsights_time: "1m"
     systempool: "systempool_v1"
     nodepools: "nodepools_v1"
+    scalediagnostic_enabled: true

--- a/terraform/subscriptions/s940/c2/pre-clusters/aks.tf
+++ b/terraform/subscriptions/s940/c2/pre-clusters/aks.tf
@@ -87,6 +87,7 @@ module "aks" {
   private_dns_zone_link_name        = "${each.key}-link"
   monitor_data_collection_rule_name = "MSCI-${module.config.location}-${each.key}"
   hostencryption                    = lookup(module.config.cluster[each.key], "hostencryption", false)
+  scalediagnostic_enabled           = lookup(module.config.cluster[each.key], "scalediagnostic_enabled", false)
 }
 
 locals {

--- a/terraform/subscriptions/s940/c3/config.yaml
+++ b/terraform/subscriptions/s940/c3/config.yaml
@@ -90,3 +90,4 @@ clusters:
     networkset: "networkset1"
     network_policy: "cilium"
     activecluster: true
+    scalediagnostic_enabled: true

--- a/terraform/subscriptions/s940/c3/pre-clusters/aks.tf
+++ b/terraform/subscriptions/s940/c3/pre-clusters/aks.tf
@@ -75,6 +75,7 @@ module "aks" {
   private_dns_zone_link_name        = "${each.key}-link"
   monitor_data_collection_rule_name = "MSCI-${module.config.location}-${each.key}"
   hostencryption                    = lookup(module.config.cluster[each.key], "hostencryption", false)
+  scalediagnostic_enabled           = lookup(module.config.cluster[each.key], "scalediagnostic_enabled", false)
 
 }
 

--- a/terraform/subscriptions/s940/extmon/config.yaml
+++ b/terraform/subscriptions/s940/extmon/config.yaml
@@ -12,7 +12,6 @@ developers: ["bed2b667-ceec-4377-83f7-46888ed23887"] # AZ PIM RADIX Cluster Admi
 zoneconfig: {}
 network:
   vnet_hub_resourcegroup: "cluster-vnet-hub-extmon"
-zoneconfig:
 backend:
   resource_group_name: "s940-tfstate"
   storage_account_name: "s940radixinfra"

--- a/terraform/subscriptions/s940/prod/config.yaml
+++ b/terraform/subscriptions/s940/prod/config.yaml
@@ -102,6 +102,7 @@ clusters:
     activecluster: true
     cluster_resource_group: "clusters"
     monitor_data_collection_rule_prefix: "MSCI-NEU-"
+    scalediagnostic_enabled: true
   c1-17:
     aksversion: "1.35.1"
     networkset: "networkset2"
@@ -110,3 +111,4 @@ clusters:
     cluster_resource_group: "clusters-c1"
     systempool: "systempool_v1"
     nodepools: "nodepools_v1"
+    scalediagnostic_enabled: true

--- a/terraform/subscriptions/s940/prod/pre-clusters/aks.tf
+++ b/terraform/subscriptions/s940/prod/pre-clusters/aks.tf
@@ -87,6 +87,7 @@ module "aks" {
   private_dns_zone_link_name        = "${each.key}-link"
   monitor_data_collection_rule_name = "${lookup(module.config.cluster[each.key], "monitor_data_collection_rule_prefix", "MSCI-${module.config.location}-")}${each.key}"
   hostencryption                    = lookup(module.config.cluster[each.key], "hostencryption", false)
+  scalediagnostic_enabled           = lookup(module.config.cluster[each.key], "scalediagnostic_enabled", false)
 }
 
 locals {

--- a/terraform/subscriptions/s940/prod/pre-clusters/variables.tf
+++ b/terraform/subscriptions/s940/prod/pre-clusters/variables.tf
@@ -99,7 +99,7 @@ variable "nodepools" {
     }
     x86pipepool2 = {
       vm_size   = "Standard_E16as_v7"
-      min_count = 1
+      min_count = 7
       max_count = 50
       node_labels = {
         "nodepooltasks" = "jobs"


### PR DESCRIPTION
This pull request introduces a new optional diagnostics feature for AKS clusters, allowing the collection of logs for cluster autoscaler and Karpenter events. The feature is controlled by a new variable, which can be enabled per cluster via configuration files. The necessary Terraform resources and module wiring have been added to support this, and the feature is enabled for several clusters in different environments. Additionally, there is a change to increase the minimum node count for a specific node pool.

**Diagnostics Feature for AKS Clusters:**

* Added a new `scalediagnostic_enabled` variable to the AKS module, allowing diagnostics for cluster autoscaler and Karpenter events to be toggled on or off.
* Introduced a new `azurerm_monitor_diagnostic_setting` resource in `monitor.tf` to send relevant logs to Log Analytics when `scalediagnostic_enabled` is true.
* Updated AKS module instantiations in `pre-clusters/aks.tf` for `c2`, `c3`, and `prod` environments to pass the `scalediagnostic_enabled` value from cluster configuration. [[1]](diffhunk://#diff-21509bc1bfe6eae53f7d26b2b58112265e24f994bd233978d7180efe32f1dd24R90) [[2]](diffhunk://#diff-cb7a7ef595ac9f90102b87c86b5e2bdb7ce6e904e733fbd6169de4a04190e748R78) [[3]](diffhunk://#diff-6ba715ba15d226290c5d6abaabf8c159c662f629bcc56d94e7bc8779d98fc9dfR90)
* Enabled the diagnostics feature for selected clusters in `c2`, `c3`, and `prod` configuration files. [[1]](diffhunk://#diff-a9e8334e91cd53e7986fa0bc661c9d79837a44aaecfccbb9a5eb8c458ec6daebR80) [[2]](diffhunk://#diff-a9e8334e91cd53e7986fa0bc661c9d79837a44aaecfccbb9a5eb8c458ec6daebR90) [[3]](diffhunk://#diff-e4e860dad79eadc4ffc76c9c37cd5aa0783a2482851e49218786d31c2e3e0119R93) [[4]](diffhunk://#diff-93f686ec587068c3adf94908619427bdc48700ffa18d3bafa6e6e911924cac61R105) [[5]](diffhunk://#diff-93f686ec587068c3adf94908619427bdc48700ffa18d3bafa6e6e911924cac61R114)

**Node Pool Configuration:**

* Increased the `min_count` for the `x86pipepool2` node pool from 1 to 7 in the production environment, ensuring greater baseline capacity.…ents