### PR TITLE
feat: update README and scripts to reflect External Secrets integrati…

### DIFF
--- a/.github/workflows/scripts/check_resource_lock.sh
+++ b/.github/workflows/scripts/check_resource_lock.sh
@@ -43,7 +43,7 @@ RADIX_ZONE_YAML=$(cat <<EOF
 $(<$RADIX_ZONE_ENV)
 EOF
 )
-AZ_RESOURCE_KEYVAULT=$(jq -r .keyvault <<< "$RADIX_RESOURCE_JSON")
+AZ_RESOURCE_KEYVAULT=$(jq -r .keyvault_main <<< "$RADIX_RESOURCE_JSON")
 AZ_SUBSCRIPTION_ID=$(yq '.backend.subscription_id' <<< "$RADIX_ZONE_YAML")
 AZ_RESOURCE_GROUP_CLUSTERS=$(jq -r .cluster_rg <<< "$RADIX_RESOURCE_JSON")
 

--- a/scripts/cert-manager/cluster-issuers/digicert/update_account.sh
+++ b/scripts/cert-manager/cluster-issuers/digicert/update_account.sh
@@ -114,7 +114,7 @@ $(<$RADIX_ZONE_ENV)
 EOF
 )
 AZ_SUBSCRIPTION_ID=$(yq '.backend.subscription_id' <<< "$RADIX_ZONE_YAML")
-AZ_RESOURCE_KEYVAULT=$(jq -r .keyvault <<< "$RADIX_RESOURCE_JSON")
+AZ_RESOURCE_KEYVAULT=$(jq -r .keyvault_main <<< "$RADIX_RESOURCE_JSON")
 DIGICERT_EXTERNAL_ACCOUNT_KV_SECRET="digicert-external-account"
 #######################################################################################
 ### Prepare az session

--- a/scripts/check_keyvault_secrets.sh
+++ b/scripts/check_keyvault_secrets.sh
@@ -81,7 +81,7 @@ $(<$RADIX_ZONE_ENV)
 EOF
 )
 AZ_SUBSCRIPTION_ID=$(yq '.backend.subscription_id' <<< "$RADIX_ZONE_YAML")
-AZ_RESOURCE_KEYVAULT=$(jq -r .keyvault <<< "$RADIX_RESOURCE_JSON")
+AZ_RESOURCE_KEYVAULT=$(jq -r .keyvault_main <<< "$RADIX_RESOURCE_JSON")
 
 #######################################################################################
 ### Prepare az session

--- a/scripts/cicd-canary/update_auth_secret.sh
+++ b/scripts/cicd-canary/update_auth_secret.sh
@@ -58,7 +58,7 @@ $(<$RADIX_ZONE_ENV)
 EOF
 )
 AZ_SUBSCRIPTION_ID=$(yq '.backend.subscription_id' <<< "$RADIX_ZONE_YAML")
-AZ_RESOURCE_KEYVAULT=$(jq -r .keyvault <<< "$RADIX_RESOURCE_JSON")
+AZ_RESOURCE_KEYVAULT=$(jq -r .keyvault_main <<< "$RADIX_RESOURCE_JSON")
 
 # Local variables
 

--- a/scripts/cicd-canary/update_secret_for_networkpolicy_canary.sh
+++ b/scripts/cicd-canary/update_secret_for_networkpolicy_canary.sh
@@ -87,7 +87,7 @@ EOF
 AZ_SUBSCRIPTION_ID=$(yq '.backend.subscription_id' <<< "$RADIX_ZONE_YAML")
 AZ_RESOURCE_GROUP_CLUSTERS=$(jq -r .cluster_rg <<< "$RADIX_RESOURCE_JSON")
 OAUTH2_PROXY_SCOPE="openid profile offline_access 6dae42f8-4368-4678-94ff-3960e28e3630/user.read email"
-AZ_RESOURCE_KEYVAULT=$(jq -r .keyvault <<< "$RADIX_RESOURCE_JSON")
+AZ_RESOURCE_KEYVAULT=$(jq -r .keyvault_main <<< "$RADIX_RESOURCE_JSON")
 AZ_RESOURCE_DNS=$(jq -r .dns_zone <<< "$RADIX_RESOURCE_JSON")
 APP_REGISTRATION_NETWORKPOLICY_CANARY=$(yq '.zoneconfig.APP_REGISTRATION_NETWORKPOLICY_CANARY' <<< "$RADIX_ZONE_YAML")
 echo ""

--- a/scripts/dockerhub/update_docker_auth.sh
+++ b/scripts/dockerhub/update_docker_auth.sh
@@ -97,7 +97,7 @@ $(<$RADIX_ZONE_ENV)
 EOF
 )
 AZ_SUBSCRIPTION_ID=$(yq '.backend.subscription_id' <<< "$RADIX_ZONE_YAML")
-AZ_RESOURCE_KEYVAULT=$(jq -r .keyvault <<< "$RADIX_RESOURCE_JSON")
+AZ_RESOURCE_KEYVAULT=$(jq -r .keyvault_main <<< "$RADIX_RESOURCE_JSON")
 #######################################################################################
 ### Prepare az session
 ###

--- a/scripts/flux/rotatekey.sh
+++ b/scripts/flux/rotatekey.sh
@@ -73,7 +73,7 @@ EOF
 )
 AZ_SUBSCRIPTION_ID=$(yq '.backend.subscription_id' <<< "$RADIX_ZONE_YAML")
 AZ_RESOURCE_GROUP_CLUSTERS=$(jq -r .cluster_rg <<< "$RADIX_RESOURCE_JSON")
-AZ_RESOURCE_KEYVAULT=$(jq -r .keyvault <<< "$RADIX_RESOURCE_JSON")
+AZ_RESOURCE_KEYVAULT=$(jq -r .keyvault_main <<< "$RADIX_RESOURCE_JSON")
 FLUX_PRIVATE_KEY_NAME="flux-github-deploy-key-private"
 
 #######################################################################################

--- a/scripts/migrate.sh
+++ b/scripts/migrate.sh
@@ -158,7 +158,7 @@ function get_variables() {
     AZ_RESOURCE_GROUP_CLUSTERS=$(jq -r .cluster_rg <<< "$RADIX_RESOURCE_JSON")
     AZ_RESOURCE_GROUP_COMMON=$(jq -r .common_rg <<< "$RADIX_RESOURCE_JSON")
     AZ_RESOURCE_GROUP_DNS=$(jq -r .dns_zone_resource_group <<< "$RADIX_RESOURCE_JSON")
-    AZ_RESOURCE_KEYVAULT=$(jq -r .keyvault <<< "$RADIX_RESOURCE_JSON")
+    AZ_RESOURCE_KEYVAULT=$(jq -r .keyvault_config <<< "$RADIX_RESOURCE_JSON")
     IMAGE_REGISTRY=$(jq -r .acr <<< "$RADIX_RESOURCE_JSON")
     RADIX_CACHE_REGISTRY=$(jq -r .cache_registry <<< "$RADIX_RESOURCE_JSON")
     CLUSTER_OIDC_ISSUER_URLS=$(jq -r .cluster_issuer_urls <<< "$RADIX_RESOURCE_JSON")

--- a/scripts/service-principals-and-aad-apps/README.md
+++ b/scripts/service-principals-and-aad-apps/README.md
@@ -62,7 +62,7 @@ For any other SP see the bootstrap/teardown scripts for the components that requ
 
 Refreshing credentials for a service principal is usually a four step process for most components:
 1. Refresh secret (..."password") in Azure AD
-1. Update credentials in key vault in a reusable format (see [`template-credentials.json`](./template-credentials.json))
+1. Update credentials in the main key vault in a reusable format (see [`template-credentials.json`](./template-credentials.json)). This is the vault consumed by External Secrets in radix-flux.
 1. External Secrets reads credentials from key vault and updates Kubernetes secrets automatically for configured `ExternalSecret` resources
 1. Restart component pods only if the component does not hot-reload updated credentials
 

--- a/scripts/service-principals-and-aad-apps/README.md
+++ b/scripts/service-principals-and-aad-apps/README.md
@@ -63,12 +63,8 @@ For any other SP see the bootstrap/teardown scripts for the components that requ
 Refreshing credentials for a service principal is usually a four step process for most components:
 1. Refresh secret (..."password") in Azure AD
 1. Update credentials in key vault in a reusable format (see [`template-credentials.json`](./template-credentials.json))
-1. Update the credentials for the component that use this SP in the cluster  
-   This process should be an automated process specific to each component,  
-   - Read the credentials from key vault, 
-   - Reformat them to how ever the component wants them using a template and...
-   - Upload them as a k8s secret into the cluster
-1. Restart the component pods to force it to read the updated k8s secret(s)
+1. External Secrets reads credentials from key vault and updates Kubernetes secrets automatically for configured `ExternalSecret` resources
+1. Restart component pods only if the component does not hot-reload updated credentials
 
 Keep in mind the following:
 
@@ -90,14 +86,9 @@ Keep in mind the following:
    Multiple components may use the same service principal and refreshing credentials in AAD will impact all of them 
    - If yes to refresh credentials in AAD: 
      Refresh credentials in AAD and store them in keyvault by using script [`refresh_service_principal_credentials.sh`](./refresh_service_principal_credentials.sh)
-1. Manually update the credentials in the clusters for the component that use it  
-   Usually the easiest way to do this is 
-   1. Run install base components script to update k8s secrets
-   1. Delete all the running pods of the component so that k8s will redeploy them with updated k8s secret  
-      Examples:
-      - Delete all `external-dns` pods to refresh DNS credentials
-      - Delete all `cert-manager` pods to refresh DNS credentials
-      - Delete all `radix-operator` pods to refresh ACR/CICD credentials
+1. Verify the related `ExternalSecret` exists in radix-flux and references the correct key vault secret
+1. Wait for External Secrets reconciliation (typically `refreshInterval: 5m` in radix-flux)
+1. Restart component pods only if needed for applications that do not reload secrets automatically
 
 
 #### Refresh component AAD app credentials
@@ -106,10 +97,9 @@ Keep in mind the following:
    Multiple components may use the same AAD app and refreshing credentials in AAD will impact all of them
    - If yes to refresh credentials in AAD: 
      Refresh credentials in AAD and store them in keyvault by using script [`refresh_aad_app_credentials.sh`](./refresh_aad_app_credentials.sh)
-1. Manually update the credentials in the clusters for the component that use it  
-   Usually the easiest way to do this is 
-   1. Run install base components script to update k8s secrets
-   1. Delete all the running pods of the component so that k8s will redeploy them with updated k8s secret
+1. Verify the related `ExternalSecret` exists in radix-flux and references the correct key vault secret
+1. Wait for External Secrets reconciliation (typically `refreshInterval: 5m` in radix-flux)
+1. Restart component pods only if needed for applications that do not reload secrets automatically
 
 
 

--- a/scripts/service-principals-and-aad-apps/refresh_aad_app_credentials.sh
+++ b/scripts/service-principals-and-aad-apps/refresh_aad_app_credentials.sh
@@ -25,7 +25,7 @@
 ### HOW TO USE
 ###
 
-# RADIX_ZONE=dev AAD_APP_NAME=demo-rbac-dev ./refresh_aad_app_credentials.sh
+# RADIX_ZONE=dev AAD_APP_NAME=demo-rbac-dev SECRET=demo-rbac ./refresh_aad_app_credentials.sh
 # This makes the JSON look like
 # {
 #   "name": "",
@@ -57,8 +57,8 @@ hash jq 2>/dev/null || {
     echo -e "\nERROR: jq not found in PATH. Exiting... " >&2
     exit 1
 }
-hash kubectl 2>/dev/null || {
-    echo -e "\nERROR: kubectl not found in PATH. Exiting... " >&2
+hash yq 2>/dev/null || {
+    echo -e "\nERROR: yq not found in PATH. Exiting... " >&2
     exit 1
 }
 printf "Done.\n"
@@ -78,7 +78,7 @@ else
 fi
 
 if [[ -z "$AAD_APP_NAME" ]]; then
-    echo "ERROR: Please provide SP_NAME" >&2
+    echo "ERROR: Please provide AAD_APP_NAME" >&2
     exit 1
 fi
 
@@ -116,7 +116,7 @@ $(<$RADIX_ZONE_ENV)
 EOF
 )
 AZ_SUBSCRIPTION_ID=$(yq '.backend.subscription_id' <<< "$RADIX_ZONE_YAML")
-AZ_RESOURCE_KEYVAULT=$(jq -r .keyvault <<< "$RADIX_RESOURCE_JSON")
+AZ_RESOURCE_KEYVAULT=$(jq -r .keyvault_main <<< "$RADIX_RESOURCE_JSON")
 
 #######################################################################################
 ### Prepare az session
@@ -179,8 +179,8 @@ refresh_ad_app_and_store_credentials_in_ad_and_keyvault "$AAD_APP_NAME" "$SECRET
 ###
 
 echo ""
-echo ">> You must manually update credentials in the clusters."
-echo ">> See README for which workflow to use depending on use case."
+echo ">> Credentials in clusters are updated automatically by External Secrets when configured."
+echo ">> Verify matching ExternalSecret in radix-flux and allow time for reconcile (typically 5 minutes)."
 
 #######################################################################################
 ### END

--- a/scripts/service-principals-and-aad-apps/refresh_aad_app_credentials.sh
+++ b/scripts/service-principals-and-aad-apps/refresh_aad_app_credentials.sh
@@ -36,6 +36,11 @@
 #   "secretId": ""
 # }
 
+#######################################################################################
+### Typical usage
+### RADIX_ZONE={zone} AAD_APP_NAME=radix-cr-cicd-{zone} SECRET=radix-cr-cicd ./refresh_aad_app_credentials.sh
+
+
 
 #######################################################################################
 ### START

--- a/scripts/service-principals-and-aad-apps/refresh_service_principal_credentials.sh
+++ b/scripts/service-principals-and-aad-apps/refresh_service_principal_credentials.sh
@@ -45,8 +45,8 @@ hash jq 2>/dev/null || {
     echo -e "\nERROR: jq not found in PATH. Exiting... " >&2
     exit 1
 }
-hash kubectl 2>/dev/null || {
-    echo -e "\nERROR: kubectl not found in PATH. Exiting... " >&2
+hash yq 2>/dev/null || {
+    echo -e "\nERROR: yq not found in PATH. Exiting... " >&2
     exit 1
 }
 printf "Done.\n"
@@ -98,7 +98,7 @@ $(<$RADIX_ZONE_ENV)
 EOF
 )
 AZ_SUBSCRIPTION_ID=$(yq '.backend.subscription_id' <<< "$RADIX_ZONE_YAML")
-AZ_RESOURCE_KEYVAULT=$(jq -r .keyvault <<< "$RADIX_RESOURCE_JSON")
+AZ_RESOURCE_KEYVAULT=$(jq -r .keyvault_main <<< "$RADIX_RESOURCE_JSON")
 #######################################################################################
 ### Prepare az session
 ###
@@ -161,8 +161,8 @@ refresh_service_principal_and_store_credentials_in_ad_and_keyvault "$SP_NAME"
 ###
 
 echo ""
-echo ">> You must manually update credentials in the clusters."
-echo ">> See README for which workflow to use depending on use case."
+echo ">> Credentials in clusters are updated automatically by External Secrets when configured."
+echo ">> Verify matching ExternalSecret in radix-flux and allow time for reconcile (typically 5 minutes)."
 
 #######################################################################################
 ### END

--- a/scripts/servicenow-proxy/refresh_api_key.sh
+++ b/scripts/servicenow-proxy/refresh_api_key.sh
@@ -103,7 +103,7 @@ EOF
 )
 
 AZ_SUBSCRIPTION_ID=$(yq '.backend.subscription_id' <<< "$RADIX_ZONE_YAML")
-AZ_RESOURCE_KEYVAULT=$(jq -r .keyvault <<< "$RADIX_RESOURCE_JSON")
+AZ_RESOURCE_KEYVAULT=$(jq -r .keyvault_main <<< "$RADIX_RESOURCE_JSON")
 KV_SECRET_SERVICENOW_API_KEY="servicenow-api-key"
 #######################################################################################
 ### Prepare az session

--- a/scripts/update_secret_for_radix_servicenow_proxy.sh
+++ b/scripts/update_secret_for_radix_servicenow_proxy.sh
@@ -101,7 +101,7 @@ EOF
 # AZ_RADIX_ZONE_LOCATION=$(yq '.location' <<< "$RADIX_ZONE_YAML")
 AZ_RESOURCE_GROUP_CLUSTERS=$(jq -r .cluster_rg <<< "$RADIX_RESOURCE_JSON")
 AZ_SUBSCRIPTION_ID=$(yq '.backend.subscription_id' <<< "$RADIX_ZONE_YAML")
-AZ_RESOURCE_KEYVAULT=$(jq -r .keyvault <<< "$RADIX_RESOURCE_JSON")
+AZ_RESOURCE_KEYVAULT=$(jq -r .keyvault_main <<< "$RADIX_RESOURCE_JSON")
 
 
 #######################################################################################

--- a/scripts/utility/util.sh
+++ b/scripts/utility/util.sh
@@ -84,6 +84,7 @@ function environment_json() {
   local az_resource_group_common=$(terraform -chdir="$RADIX_PLATFORM_REPOSITORY_PATH/terraform/subscriptions/$AZ_SUBSCRIPTION_NAME/$RADIX_ZONE/base-infrastructure" output -raw az_resource_group_common)
   local velero_storage_account=$(terraform -chdir="$RADIX_PLATFORM_REPOSITORY_PATH/terraform/subscriptions/$AZ_SUBSCRIPTION_NAME/$RADIX_ZONE/base-infrastructure" output -raw velero_storage_account)
   local keyvault_name=$(terraform -chdir="$RADIX_PLATFORM_REPOSITORY_PATH/terraform/subscriptions/$AZ_SUBSCRIPTION_NAME/$RADIX_ZONE/base-infrastructure" output -raw keyvault_config_name)
+  local keyvault_main=$(terraform -chdir="$RADIX_PLATFORM_REPOSITORY_PATH/terraform/subscriptions/$AZ_SUBSCRIPTION_NAME/$RADIX_ZONE/base-infrastructure" output -raw keyvault_name)
   local dns_zone_name=$(terraform -chdir="$RADIX_PLATFORM_REPOSITORY_PATH/terraform/subscriptions/$AZ_SUBSCRIPTION_NAME/$RADIX_ZONE/base-infrastructure" output -raw dns_zone_name)
   local imageRegistry=$(terraform -chdir="$RADIX_PLATFORM_REPOSITORY_PATH/terraform/subscriptions/$AZ_SUBSCRIPTION_NAME/$RADIX_ZONE/base-infrastructure" output -raw imageRegistry)
   local ip_prefix_egress=$(terraform -chdir="$RADIX_PLATFORM_REPOSITORY_PATH/terraform/subscriptions/$AZ_SUBSCRIPTION_NAME/$RADIX_ZONE/base-infrastructure" output -json public_ip_prefix_names | jq -r .egress)
@@ -100,6 +101,7 @@ function environment_json() {
     "common_rg": "$az_resource_group_common",
     "velero_sa": "$velero_storage_account",
     "keyvault" : "$keyvault_name",
+    "keyvault_main" : "$keyvault_main",
     "dns_zone": "$dns_zone_name",
     "acr": "$imageRegistry",
     "egress_prefix": "$ip_prefix_egress",

--- a/scripts/utility/util.sh
+++ b/scripts/utility/util.sh
@@ -83,7 +83,7 @@ function environment_json() {
   local az_resource_group_clusters=$(terraform -chdir="$RADIX_PLATFORM_REPOSITORY_PATH/terraform/subscriptions/$AZ_SUBSCRIPTION_NAME/$RADIX_ZONE/base-infrastructure" output -raw az_resource_group_clusters)
   local az_resource_group_common=$(terraform -chdir="$RADIX_PLATFORM_REPOSITORY_PATH/terraform/subscriptions/$AZ_SUBSCRIPTION_NAME/$RADIX_ZONE/base-infrastructure" output -raw az_resource_group_common)
   local velero_storage_account=$(terraform -chdir="$RADIX_PLATFORM_REPOSITORY_PATH/terraform/subscriptions/$AZ_SUBSCRIPTION_NAME/$RADIX_ZONE/base-infrastructure" output -raw velero_storage_account)
-  local keyvault_name=$(terraform -chdir="$RADIX_PLATFORM_REPOSITORY_PATH/terraform/subscriptions/$AZ_SUBSCRIPTION_NAME/$RADIX_ZONE/base-infrastructure" output -raw keyvault_config_name)
+  local keyvault_config=$(terraform -chdir="$RADIX_PLATFORM_REPOSITORY_PATH/terraform/subscriptions/$AZ_SUBSCRIPTION_NAME/$RADIX_ZONE/base-infrastructure" output -raw keyvault_config_name)
   local keyvault_main=$(terraform -chdir="$RADIX_PLATFORM_REPOSITORY_PATH/terraform/subscriptions/$AZ_SUBSCRIPTION_NAME/$RADIX_ZONE/base-infrastructure" output -raw keyvault_name)
   local dns_zone_name=$(terraform -chdir="$RADIX_PLATFORM_REPOSITORY_PATH/terraform/subscriptions/$AZ_SUBSCRIPTION_NAME/$RADIX_ZONE/base-infrastructure" output -raw dns_zone_name)
   local imageRegistry=$(terraform -chdir="$RADIX_PLATFORM_REPOSITORY_PATH/terraform/subscriptions/$AZ_SUBSCRIPTION_NAME/$RADIX_ZONE/base-infrastructure" output -raw imageRegistry)
@@ -100,7 +100,7 @@ function environment_json() {
     "cluster_rg": "$az_resource_group_clusters",
     "common_rg": "$az_resource_group_common",
     "velero_sa": "$velero_storage_account",
-    "keyvault" : "$keyvault_name",
+    "keyvault_config" : "$keyvault_config",
     "keyvault_main" : "$keyvault_main",
     "dns_zone": "$dns_zone_name",
     "acr": "$imageRegistry",

--- a/scripts/velero/bootstrap.sh
+++ b/scripts/velero/bootstrap.sh
@@ -103,7 +103,7 @@ EOF
 )
 AZ_SUBSCRIPTION_ID=$(yq '.backend.subscription_id' <<< "$RADIX_ZONE_YAML")
 RADIX_ENVIRONMENT=$(yq '.radix_environment' <<< "$RADIX_ZONE_YAML")
-AZ_RESOURCE_KEYVAULT=$(jq -r .keyvault <<< "$RADIX_RESOURCE_JSON")
+AZ_RESOURCE_KEYVAULT=$(jq -r .keyvault_main <<< "$RADIX_RESOURCE_JSON")
 AZ_VELERO_RESOURCE_GROUP=$(jq -r .common_rg <<< "$RADIX_RESOURCE_JSON")
 AZ_VELERO_STORAGE_ACCOUNT_ID=$(jq -r .velero_sa <<< "$RADIX_RESOURCE_JSON")
 #######################################################################################


### PR DESCRIPTION
This pull request standardizes how Azure Key Vault names are referenced throughout various scripts and updates documentation and helper scripts to reflect changes in secret management workflows. The main focus is on ensuring scripts consistently use the correct key vault variable from the environment JSON and aligning the process with the usage of External Secrets for Kubernetes secret updates.

Key changes include:

**Key Vault Variable Standardization:**
* Updated all scripts to reference `keyvault_main` (or `keyvault_config` where appropriate) instead of the previous `keyvault` variable when extracting the Key Vault name from `RADIX_RESOURCE_JSON`. This ensures consistency and correct vault usage across all automation scripts.

**Environment JSON Structure Update:**
* Modified the `environment_json` function in `util.sh` to output both `keyvault_config` and `keyvault_main` fields instead of a single `keyvault` field, reflecting the new naming convention and supporting the above script changes. 

**Secret Management Workflow Improvements:**
* Updated documentation in `README.md` and script output messages to clarify that credentials are now automatically updated in Kubernetes clusters via External Secrets, removing the need for manual secret updates and most pod restarts. Instructions now emphasize verifying `ExternalSecret` resources and waiting for reconciliation. 

**Helper Script Enhancements:**
* Updated helper scripts to require `yq` (YAML processor) instead of `kubectl` for parsing, and improved error messages for missing environment variables. 

**Usage Documentation:**
* Improved usage instructions and variable naming in credential refresh scripts to match the new conventions and clarify required parameters. 

These changes improve maintainability, reduce manual intervention, and align the secret management workflow with current best practices using External Secrets.